### PR TITLE
Store epoch ids as bytes

### DIFF
--- a/rolling-shutter/decryptor/dcrdb/models.go
+++ b/rolling-shutter/decryptor/dcrdb/models.go
@@ -5,17 +5,17 @@ package dcrdb
 import ()
 
 type DecryptorCipherBatch struct {
-	EpochID int64
+	EpochID []byte
 	Data    []byte
 }
 
 type DecryptorDecryptionKey struct {
-	EpochID int64
+	EpochID []byte
 	Key     []byte
 }
 
 type DecryptorDecryptionSignature struct {
-	EpochID     int64
+	EpochID     []byte
 	SignedHash  []byte
 	SignerIndex int64
 	Signature   []byte

--- a/rolling-shutter/decryptor/dcrdb/query.sql.go
+++ b/rolling-shutter/decryptor/dcrdb/query.sql.go
@@ -14,7 +14,7 @@ SELECT epoch_id, data FROM decryptor.cipher_batch
 WHERE epoch_id = $1
 `
 
-func (q *Queries) GetCipherBatch(ctx context.Context, epochID int64) (DecryptorCipherBatch, error) {
+func (q *Queries) GetCipherBatch(ctx context.Context, epochID []byte) (DecryptorCipherBatch, error) {
 	row := q.db.QueryRow(ctx, getCipherBatch, epochID)
 	var i DecryptorCipherBatch
 	err := row.Scan(&i.EpochID, &i.Data)
@@ -26,7 +26,7 @@ SELECT epoch_id, key FROM decryptor.decryption_key
 WHERE epoch_id = $1
 `
 
-func (q *Queries) GetDecryptionKey(ctx context.Context, epochID int64) (DecryptorDecryptionKey, error) {
+func (q *Queries) GetDecryptionKey(ctx context.Context, epochID []byte) (DecryptorDecryptionKey, error) {
 	row := q.db.QueryRow(ctx, getDecryptionKey, epochID)
 	var i DecryptorDecryptionKey
 	err := row.Scan(&i.EpochID, &i.Key)
@@ -39,7 +39,7 @@ WHERE epoch_id = $1 AND signer_index = $2
 `
 
 type GetDecryptionSignatureParams struct {
-	EpochID     int64
+	EpochID     []byte
 	SignerIndex int64
 }
 
@@ -76,7 +76,7 @@ ON CONFLICT DO NOTHING
 `
 
 type InsertCipherBatchParams struct {
-	EpochID int64
+	EpochID []byte
 	Data    []byte
 }
 
@@ -94,7 +94,7 @@ ON CONFLICT DO NOTHING
 `
 
 type InsertDecryptionKeyParams struct {
-	EpochID int64
+	EpochID []byte
 	Key     []byte
 }
 
@@ -112,7 +112,7 @@ ON CONFLICT DO NOTHING
 `
 
 type InsertDecryptionSignatureParams struct {
-	EpochID     int64
+	EpochID     []byte
 	SignedHash  []byte
 	SignerIndex int64
 	Signature   []byte

--- a/rolling-shutter/decryptor/dcrdb/schema.sql
+++ b/rolling-shutter/decryptor/dcrdb/schema.sql
@@ -1,4 +1,4 @@
--- schema-version: 1 --
+-- schema-version: 2 --
 -- Please change the version above if you make incompatible changes to
 -- the schema. We'll use this to check we're using the right schema.
 
@@ -6,15 +6,15 @@
 CREATE SCHEMA IF NOT EXISTS decryptor;
 
 CREATE TABLE IF NOT EXISTS decryptor.cipher_batch (
-       epoch_id bigint PRIMARY KEY,
+       epoch_id bytea PRIMARY KEY,
        data bytea
 );
 CREATE TABLE IF NOT EXISTS decryptor.decryption_key (
-       epoch_id bigint PRIMARY KEY,
+       epoch_id bytea PRIMARY KEY,
        key bytea
 );
 CREATE TABLE IF NOT EXISTS decryptor.decryption_signature (
-       epoch_id bigint,
+       epoch_id bytea,
        signed_hash bytea,
        signer_index bigint,
        signature bytea,

--- a/rolling-shutter/decryptor/inputhandling_test.go
+++ b/rolling-shutter/decryptor/inputhandling_test.go
@@ -47,12 +47,12 @@ func TestInsertDecryptionKeyIntegration(t *testing.T) {
 		t.Fatalf("error handling input: %v", err)
 	}
 
-	mStored, err := db.GetDecryptionKey(ctx, int64(m.EpochID))
+	mStored, err := db.GetDecryptionKey(ctx, medley.Uint64EpochIDToBytes(m.EpochID))
 	if err != nil {
 		t.Fatalf("error retrieving decryption key: %v", err)
 	}
 
-	if mStored.EpochID != int64(m.EpochID) {
+	if medley.BytesEpochIDToUint64(mStored.EpochID) != m.EpochID {
 		t.Errorf("wrong epoch id")
 	}
 	if !bytes.Equal(mStored.Key, m.Key) {
@@ -67,7 +67,7 @@ func TestInsertDecryptionKeyIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error handling input: %v", err)
 	}
-	m2Stored, err := db.GetDecryptionKey(ctx, int64(m.EpochID))
+	m2Stored, err := db.GetDecryptionKey(ctx, medley.Uint64EpochIDToBytes(m.EpochID))
 	if err != nil {
 		t.Fatalf("error retrieving decryption key: %v", err)
 	}
@@ -95,12 +95,12 @@ func TestInsertCipherBatchIntegration(t *testing.T) {
 		t.Fatalf("error handling input: %v", err)
 	}
 
-	mStored, err := db.GetCipherBatch(ctx, int64(m.EpochID))
+	mStored, err := db.GetCipherBatch(ctx, medley.Uint64EpochIDToBytes(m.EpochID))
 	if err != nil {
 		t.Fatalf("error retrieving cipher batch: %v", err)
 	}
 
-	if mStored.EpochID != int64(m.EpochID) {
+	if medley.BytesEpochIDToUint64(mStored.EpochID) != m.EpochID {
 		t.Errorf("wrong epoch id")
 	}
 	if !bytes.Equal(mStored.Data, m.Data) {
@@ -115,7 +115,7 @@ func TestInsertCipherBatchIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error handling input: %v", err)
 	}
-	m2Stored, err := db.GetCipherBatch(ctx, int64(m.EpochID))
+	m2Stored, err := db.GetCipherBatch(ctx, medley.Uint64EpochIDToBytes(m.EpochID))
 	if err != nil {
 		t.Fatalf("error retrieving data: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestHandleEpochIntegration(t *testing.T) {
 	// TODO: handle signer index
 	storedDecryptionKey,
 		err := db.GetDecryptionSignature(ctx, dcrdb.GetDecryptionSignatureParams{
-		EpochID:     int64(cipherBatchMsg.EpochID),
+		EpochID:     medley.Uint64EpochIDToBytes(cipherBatchMsg.EpochID),
 		SignerIndex: 0,
 	})
 	if err != nil {
@@ -171,7 +171,12 @@ func TestHandleEpochIntegration(t *testing.T) {
 		if !ok {
 			t.Errorf("wrong type")
 		}
-		assert.Equal(t, storedDecryptionKey.EpochID, int64(msg.EpochID), "stored and output epoch id do not match")
+		assert.Equal(
+			t,
+			medley.BytesEpochIDToUint64(storedDecryptionKey.EpochID),
+			msg.EpochID,
+			"stored and output epoch id do not match",
+		)
 		if !bytes.Equal(storedDecryptionKey.SignedHash, msg.SignedHash) {
 			t.Errorf("stored and output signed hash do not match")
 		}

--- a/rolling-shutter/keyper/kprdb/models.go
+++ b/rolling-shutter/keyper/kprdb/models.go
@@ -7,19 +7,19 @@ import (
 )
 
 type KeyperDecryptionKey struct {
-	EpochID       int64
+	EpochID       []byte
 	KeyperIndex   sql.NullInt64
 	DecryptionKey []byte
 }
 
 type KeyperDecryptionKeyShare struct {
-	EpochID            int64
+	EpochID            []byte
 	KeyperIndex        int64
 	DecryptionKeyShare []byte
 }
 
 type KeyperDecryptionTrigger struct {
-	EpochID int64
+	EpochID []byte
 }
 
 type KeyperMetaInf struct {

--- a/rolling-shutter/keyper/kprdb/query.sql.go
+++ b/rolling-shutter/keyper/kprdb/query.sql.go
@@ -12,7 +12,7 @@ SELECT epoch_id, keyper_index, decryption_key FROM keyper.decryption_key
 WHERE epoch_id = $1
 `
 
-func (q *Queries) GetDecryptionKey(ctx context.Context, epochID int64) (KeyperDecryptionKey, error) {
+func (q *Queries) GetDecryptionKey(ctx context.Context, epochID []byte) (KeyperDecryptionKey, error) {
 	row := q.db.QueryRow(ctx, getDecryptionKey, epochID)
 	var i KeyperDecryptionKey
 	err := row.Scan(&i.EpochID, &i.KeyperIndex, &i.DecryptionKey)

--- a/rolling-shutter/keyper/kprdb/schema.sql
+++ b/rolling-shutter/keyper/kprdb/schema.sql
@@ -1,19 +1,19 @@
--- schema-version: 1 --
+-- schema-version: 2 --
 -- Please change the version above if you make incompatible changes to
 -- the schema. We'll use this to check we're using the right schema.
 
 CREATE SCHEMA IF NOT EXISTS keyper;
 CREATE TABLE IF NOT EXISTS keyper.decryption_trigger (
-       epoch_id bigint PRIMARY KEY
+       epoch_id bytea PRIMARY KEY
 );
 CREATE TABLE IF NOT EXISTS keyper.decryption_key_share (
-       epoch_id bigint,
+       epoch_id bytea,
        keyper_index bigint,
        decryption_key_share bytea,
        PRIMARY KEY (epoch_id, keyper_index)
 );
 CREATE TABLE IF NOT EXISTS keyper.decryption_key (
-       epoch_id bigint PRIMARY KEY,
+       epoch_id bytea PRIMARY KEY,
        keyper_index bigint,
        decryption_key bytea
 );

--- a/rolling-shutter/medley/epochid.go
+++ b/rolling-shutter/medley/epochid.go
@@ -1,0 +1,13 @@
+package medley
+
+import "encoding/binary"
+
+func Uint64EpochIDToBytes(epochID uint64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, epochID)
+	return b
+}
+
+func BytesEpochIDToUint64(b []byte) uint64 {
+	return binary.LittleEndian.Uint64(b)
+}


### PR DESCRIPTION
There are alternatives (`numeric`, `int64`), but I didn't like any of them, so I went with bytes which is the most neutral.

Should only be merged after #34 (and will need to be rebased)

Closes #33 