### PR TITLE
Unmarshal messages received by decryptor to proper struct

### DIFF
--- a/rolling-shutter/decryptor/decryptor_test.go
+++ b/rolling-shutter/decryptor/decryptor_test.go
@@ -22,6 +22,9 @@ func TestMessageValidators(t *testing.T) {
 		InstanceID: 123,
 	})
 	validators := d.makeMessagesValidators()
+	validDecryptionKey := make([]byte, 64)
+	validSignature := make([]byte, 128)
+	validHash := make([]byte, 64)
 	tests := []struct {
 		valid bool
 		msg   shmsg.P2PMessage
@@ -29,37 +32,40 @@ func TestMessageValidators(t *testing.T) {
 		{
 			valid: true,
 			msg: &shmsg.DecryptionKey{
-				InstanceID: d.instanceID,
+				InstanceID: d.Config.InstanceID,
+				Key:        validDecryptionKey,
 			},
 		},
 		{
 			valid: true,
 			msg: &shmsg.AggregatedDecryptionSignature{
-				InstanceID: d.instanceID,
+				InstanceID:          d.Config.InstanceID,
+				AggregatedSignature: validSignature,
+				SignedHash:          validHash,
 			},
 		},
 		{
 			valid: true,
 			msg: &shmsg.CipherBatch{
-				InstanceID: d.instanceID,
+				InstanceID: d.Config.InstanceID,
 			},
 		},
 		{
 			valid: false,
 			msg: &shmsg.DecryptionKey{
-				InstanceID: d.instanceID + 1,
+				InstanceID: d.Config.InstanceID + 1,
 			},
 		},
 		{
 			valid: false,
 			msg: &shmsg.AggregatedDecryptionSignature{
-				InstanceID: d.instanceID - 1,
+				InstanceID: d.Config.InstanceID - 1,
 			},
 		},
 		{
 			valid: false,
 			msg: &shmsg.CipherBatch{
-				InstanceID: d.instanceID + 2,
+				InstanceID: d.Config.InstanceID + 2,
 			},
 		},
 	}
@@ -71,7 +77,7 @@ func TestMessageValidators(t *testing.T) {
 		validate := validators[pubsubMessage.GetTopic()]
 		assert.Assert(t, validate != nil)
 		assert.Equal(t, validate(ctx, peerID, pubsubMessage), tc.valid,
-			"validate failed valid=%t msg=%+v", tc.valid, tc.msg)
+			"validate failed valid=%t msg=%+v type=%T", tc.valid, tc.msg, tc.msg)
 	}
 }
 

--- a/rolling-shutter/decryptor/messages.go
+++ b/rolling-shutter/decryptor/messages.go
@@ -1,0 +1,103 @@
+package decryptor
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/shutter-network/shutter/shlib/shcrypto"
+	"github.com/shutter-network/shutter/shlib/shcrypto/shbls"
+	"github.com/shutter-network/shutter/shuttermint/decryptor/dcrtopics"
+	"github.com/shutter-network/shutter/shuttermint/p2p"
+	"github.com/shutter-network/shutter/shuttermint/shmsg"
+)
+
+type decryptionSignature struct {
+	instanceID     uint64
+	epochID        uint64
+	signedHash     common.Hash
+	signature      *shbls.Signature
+	SignerBitfield []byte
+}
+
+type decryptionKey struct {
+	instanceID uint64
+	epochID    uint64
+	key        *shcrypto.EpochSecretKey
+}
+type cipherBatch shmsg.CipherBatch
+
+type message interface {
+	implementsMessage()
+	GetInstanceID() uint64
+}
+
+func (*decryptionSignature) implementsMessage() {}
+func (*decryptionKey) implementsMessage()       {}
+func (*cipherBatch) implementsMessage()         {}
+
+func (d *decryptionSignature) GetInstanceID() uint64 { return d.instanceID }
+func (d *decryptionKey) GetInstanceID() uint64       { return d.instanceID }
+func (c *cipherBatch) GetInstanceID() uint64         { return c.InstanceID }
+
+func unmarshalP2PMessage(msg *p2p.Message) (message, error) {
+	if msg == nil {
+		return nil, nil
+	}
+	switch msg.Topic {
+	case dcrtopics.DecryptionKey:
+		decryptionKeyMsg := shmsg.DecryptionKey{}
+		if err := proto.Unmarshal(msg.Message, &decryptionKeyMsg); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal decryption key P2P message")
+		}
+
+		key := new(shcrypto.EpochSecretKey)
+		if err := key.GobDecode(decryptionKeyMsg.Key); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal decryption key")
+		}
+
+		return &decryptionKey{
+			instanceID: decryptionKeyMsg.InstanceID,
+			epochID:    decryptionKeyMsg.EpochID,
+			key:        key,
+		}, nil
+
+	case dcrtopics.CipherBatch:
+		cipherBatchMsg := shmsg.CipherBatch{}
+		if err := proto.Unmarshal(msg.Message, &cipherBatchMsg); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal cipher batch P2P message")
+		}
+		return (*cipherBatch)(&cipherBatchMsg), nil
+
+	case dcrtopics.DecryptionSignature:
+		decryptionSignatureMsg := shmsg.AggregatedDecryptionSignature{}
+		if err := proto.Unmarshal(msg.Message, &decryptionSignatureMsg); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal decryption signature P2P message")
+		}
+		signature := new(shbls.Signature)
+		if err := signature.Unmarshal(decryptionSignatureMsg.AggregatedSignature); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal decryption signature")
+		}
+		return &decryptionSignature{
+			instanceID:     decryptionSignatureMsg.InstanceID,
+			epochID:        decryptionSignatureMsg.EpochID,
+			signedHash:     common.BytesToHash(decryptionSignatureMsg.SignedHash),
+			signature:      signature,
+			SignerBitfield: decryptionSignatureMsg.SignerBitfield,
+		}, nil
+
+	default:
+		return nil, &unhandledTopicError{msg.Topic, "unhandled topic from P2P message"}
+	}
+}
+
+type unhandledTopicError struct {
+	topic string
+	msg   string
+}
+
+func (e *unhandledTopicError) Error() string {
+	return fmt.Sprintf("%s: %s", e.msg, e.topic)
+}


### PR DESCRIPTION
Additionally unmarshal hashes, signers, signatures, and keys from
bytes to internal types.
This will make it easier to validate the fields for incoming p2p
messages.
It should also make it easier to further use the received messages.

closes https://github.com/shutter-network/rolling-shutter/issues/47