### PR TITLE
Store aggregated signature in new db table

### DIFF
--- a/rolling-shutter/decryptor/dcrdb/models.go
+++ b/rolling-shutter/decryptor/dcrdb/models.go
@@ -4,6 +4,13 @@ package dcrdb
 
 import ()
 
+type DecryptorAggregatedSignature struct {
+	EpochID         []byte
+	SignedHash      []byte
+	SignersBitfield []byte
+	Signature       []byte
+}
+
 type DecryptorCipherBatch struct {
 	EpochID      []byte
 	Transactions [][]byte

--- a/rolling-shutter/decryptor/dcrdb/query.sql
+++ b/rolling-shutter/decryptor/dcrdb/query.sql
@@ -38,6 +38,21 @@ INSERT INTO decryptor.decryption_signature (
 )
 ON CONFLICT DO NOTHING;
 
+-- name: GetAggregatedSignature :one
+SELECT * FROM decryptor.aggregated_signature
+WHERE signed_hash = $1;
+
+-- name: ExistsAggregatedSignature :one
+SELECT EXISTS(SELECT 1 FROM decryptor.aggregated_signature WHERE signed_hash = $1);
+
+-- name: InsertAggregatedSignature :execresult
+INSERT INTO decryptor.aggregated_signature (
+    epoch_id, signed_hash, signers_bitfield, signature
+) VALUES (
+    $1, $2, $3, $4
+)
+ON CONFLICT DO NOTHING;
+
 -- name: InsertDecryptorIdentity :exec
 INSERT INTO decryptor.decryptor_identity (
     address, bls_public_key

--- a/rolling-shutter/decryptor/dcrdb/schema.sql
+++ b/rolling-shutter/decryptor/dcrdb/schema.sql
@@ -1,4 +1,4 @@
--- schema-version: 7 --
+-- schema-version: 8 --
 -- Please change the version above if you make incompatible changes to
 -- the schema. We'll use this to check we're using the right schema.
 
@@ -19,6 +19,12 @@ CREATE TABLE IF NOT EXISTS decryptor.decryption_signature (
        signers_bitfield bytea,
        signature bytea,
        PRIMARY KEY (epoch_id, signers_bitfield)
+);
+CREATE TABLE IF NOT EXISTS decryptor.aggregated_signature (
+       epoch_id bytea,
+       signed_hash bytea,
+       signers_bitfield bytea PRIMARY KEY,
+       signature bytea
 );
 CREATE TABLE IF NOT EXISTS decryptor.decryptor_identity (
        address text PRIMARY KEY,

--- a/rolling-shutter/decryptor/inputhandling_test.go
+++ b/rolling-shutter/decryptor/inputhandling_test.go
@@ -122,12 +122,95 @@ func TestHandleSignatureIntegration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db, closedb := medley.NewDecryptorTestDB(ctx, t)
-	defer closedb()
 
 	config := newTestConfig(t)
 	configTwoRequiredSignatures := config
 	configTwoRequiredSignatures.RequiredSignatures = 2
+
+	signingKey2, _, err := shbls.RandomKeyPair(rand.Reader)
+	assert.NilError(t, err)
+
+	bitfield := makeBitfieldFromIndex(1)
+	bitfield2 := makeBitfieldFromIndex(2)
+	hash := common.BytesToHash([]byte("Hello"))
+	signature := &decryptionSignature{
+		epochID:        0,
+		instanceID:     config.InstanceID,
+		signedHash:     hash,
+		signature:      shbls.Sign(hash.Bytes(), config.SigningKey),
+		SignerBitfield: bitfield,
+	}
+	signature2 := &decryptionSignature{
+		epochID:        0,
+		instanceID:     config.InstanceID,
+		signedHash:     hash,
+		signature:      shbls.Sign(hash.Bytes(), signingKey2),
+		SignerBitfield: bitfield2,
+	}
+
+	tests := []struct {
+		name    string
+		config  Config
+		inputs  []*decryptionSignature
+		outputs []*shmsg.AggregatedDecryptionSignature
+	}{
+		{
+			name:    "single signature required",
+			config:  config,
+			inputs:  []*decryptionSignature{signature},
+			outputs: []*shmsg.AggregatedDecryptionSignature{{InstanceID: config.InstanceID, SignedHash: hash.Bytes(), SignerBitfield: bitfield}},
+		},
+		{
+			name:    "two signatures required",
+			config:  configTwoRequiredSignatures,
+			inputs:  []*decryptionSignature{signature},
+			outputs: []*shmsg.AggregatedDecryptionSignature{nil},
+		},
+		{
+			name:   "two signatures required two provided",
+			config: configTwoRequiredSignatures,
+			inputs: []*decryptionSignature{signature, signature2},
+			outputs: []*shmsg.AggregatedDecryptionSignature{nil, {
+				InstanceID: configTwoRequiredSignatures.InstanceID, SignedHash: hash.Bytes(),
+				SignerBitfield: makeBitfieldFromArray([]int32{config.SignerIndex, 2}),
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		db, closedb := medley.NewDecryptorTestDB(ctx, t)
+		populateDBWithDecryptors(ctx, t, db, map[int32]*shbls.SecretKey{config.SignerIndex: config.SigningKey, 2: signingKey2})
+		t.Run(test.name, func(t *testing.T) {
+			for i, input := range test.inputs {
+				msgs, err := handleSignatureInput(ctx, test.config, db, input)
+				assert.NilError(t, err)
+				isOutputNill := test.outputs[i] == nil
+				if isOutputNill {
+					assert.Check(t, len(msgs) == 0)
+				} else {
+					assert.Check(t, len(msgs) == 1)
+					msg, ok := msgs[0].(*shmsg.AggregatedDecryptionSignature)
+					assert.Check(t, ok, "wrong message type")
+					assert.Equal(t, msg.InstanceID, test.outputs[i].InstanceID)
+					assert.Check(t, bytes.Equal(msg.SignedHash, test.outputs[i].SignedHash))
+					assert.Check(t, bytes.Equal(msg.SignerBitfield, test.outputs[i].SignerBitfield))
+				}
+			}
+		})
+		closedb()
+	}
+}
+
+func TestInsertAggregatedSignatureIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	db, closedb := medley.NewDecryptorTestDB(ctx, t)
+	defer closedb()
+
+	config := newTestConfig(t)
 
 	signingKey2, _, err := shbls.RandomKeyPair(rand.Reader)
 	assert.NilError(t, err)
@@ -152,49 +235,18 @@ func TestHandleSignatureIntegration(t *testing.T) {
 		SignerBitfield: bitfield2,
 	}
 
-	// The tests are not fully independent since database is not wiped in between each one.
-	tests := []struct {
-		config  Config
-		inputs  []*decryptionSignature
-		outputs []*shmsg.AggregatedDecryptionSignature
-	}{
-		{
-			config:  config,
-			inputs:  []*decryptionSignature{signature},
-			outputs: []*shmsg.AggregatedDecryptionSignature{{InstanceID: config.InstanceID, SignedHash: hash.Bytes(), SignerBitfield: bitfield}},
-		},
-		{
-			config:  configTwoRequiredSignatures,
-			inputs:  []*decryptionSignature{signature},
-			outputs: []*shmsg.AggregatedDecryptionSignature{nil},
-		},
-		{
-			config: configTwoRequiredSignatures,
-			inputs: []*decryptionSignature{signature, signature2},
-			outputs: []*shmsg.AggregatedDecryptionSignature{nil, {
-				InstanceID: configTwoRequiredSignatures.InstanceID, SignedHash: hash.Bytes(),
-				SignerBitfield: makeBitfieldFromArray([]int32{config.SignerIndex, 2}),
-			}},
-		},
-	}
+	msgs, err := handleSignatureInput(ctx, config, db, signature)
+	assert.NilError(t, err)
+	assert.Check(t, len(msgs) == 1)
 
-	for _, test := range tests {
-		for i, input := range test.inputs {
-			msgs, err := handleSignatureInput(ctx, test.config, db, input)
-			assert.NilError(t, err)
-			isOutputNill := test.outputs[i] == nil
-			if isOutputNill {
-				assert.Check(t, len(msgs) == 0)
-			} else {
-				assert.Check(t, len(msgs) == 1)
-				msg, ok := msgs[0].(*shmsg.AggregatedDecryptionSignature)
-				assert.Check(t, ok, "wrong message type")
-				assert.Equal(t, msg.InstanceID, test.outputs[i].InstanceID)
-				assert.Check(t, bytes.Equal(msg.SignedHash, test.outputs[i].SignedHash))
-				assert.Check(t, bytes.Equal(msg.SignerBitfield, test.outputs[i].SignerBitfield))
-			}
-		}
-	}
+	signatureStored, err := db.GetAggregatedSignature(ctx, signature.signedHash.Bytes())
+	assert.NilError(t, err)
+	assert.Equal(t, signature.epochID, medley.BytesEpochIDToUint64(signatureStored.EpochID))
+	assert.Check(t, bytes.Equal(signature.signedHash.Bytes(), signatureStored.SignedHash))
+
+	msgs, err = handleSignatureInput(ctx, config, db, signature2)
+	assert.NilError(t, err)
+	assert.Check(t, len(msgs) == 0)
 }
 
 func TestHandleEpochIntegration(t *testing.T) {


### PR DESCRIPTION
Only create and broadcast new signature if no signature for given hash was created.