### PR TITLE
Add decryption key share validator in keyper

### DIFF
--- a/rolling-shutter/medley/keygenerator.go
+++ b/rolling-shutter/medley/keygenerator.go
@@ -52,7 +52,7 @@ func (tkg *TestKeyGenerator) populateNextEonKeys() {
 	ps := []*shcrypto.Polynomial{}
 	gammas := []*shcrypto.Gammas{}
 	for i := 0; i < int(tkg.NumKeypers); i++ {
-		p, err := shcrypto.RandomPolynomial(tkg.randReader, 0)
+		p, err := shcrypto.RandomPolynomial(tkg.randReader, tkg.Threshold-1)
 		assert.NilError(tkg.t, err)
 
 		ps = append(ps, p)


### PR DESCRIPTION
There's redundancy between the key share and whole key validator. To eliminate it, I would need to write an interface implemented both by `decryptionKey` and `decryptionKeyShare`. I never know if that makes sense or not.