### PR TITLE
Keypers broadcast eon public keys when created

### DIFF
--- a/rolling-shutter/keyper/kprdb/models.go
+++ b/rolling-shutter/keyper/kprdb/models.go
@@ -53,6 +53,11 @@ type KeyperMetaInf struct {
 	Value string
 }
 
+type KeyperOutgoingEonKey struct {
+	EonPublicKey []byte
+	Eon          int64
+}
+
 type KeyperPolyEval struct {
 	Eon             int64
 	ReceiverAddress string

--- a/rolling-shutter/keyper/kprdb/query.sql
+++ b/rolling-shutter/keyper/kprdb/query.sql
@@ -180,3 +180,10 @@ VALUES ($1, $2, $3);
 SELECT * FROM keyper.chain_keyper_set
 WHERE activation_block_number <= sqlc.arg(block_number)
 ORDER BY activation_block_number DESC LIMIT 1;
+
+-- name: InsertEonPublicKey :exec
+INSERT INTO keyper.outgoing_eon_keys (eon_public_key, eon)
+VALUES ($1, $2);
+
+-- name: GetAndDeleteEonPublicKeys :many
+DELETE FROM keyper.outgoing_eon_keys RETURNING *;

--- a/rolling-shutter/keyper/kprdb/schema.sql
+++ b/rolling-shutter/keyper/kprdb/schema.sql
@@ -1,4 +1,4 @@
--- schema-version: 10 --
+-- schema-version: 11 --
 -- Please change the version above if you make incompatible changes to
 -- the schema. We'll use this to check we're using the right schema.
 
@@ -93,4 +93,10 @@ CREATE TABLE keyper.chain_keyper_set(
        activation_block_number bigint PRIMARY KEY,
        keypers text[] NOT NULL,
        threshold integer NOT NULL
+);
+
+-- outgoing_eon_keys contains the eon public key(s) that should be broadcast as a result of a successful DKG
+CREATE TABLE keyper.outgoing_eon_keys(
+       eon_public_key bytea,
+       eon bigint NOT NULL PRIMARY KEY
 );

--- a/rolling-shutter/keyper/kprtopics/kprtopics.go
+++ b/rolling-shutter/keyper/kprtopics/kprtopics.go
@@ -6,4 +6,5 @@ const (
 	DecryptionTrigger  = "decryptionTrigger"
 	DecryptionKey      = dcrtopics.DecryptionKey
 	DecryptionKeyShare = "decryptionKeyShare"
+	EonPublicKey       = "EonPublicKey"
 )

--- a/rolling-shutter/keyper/smstate.go
+++ b/rolling-shutter/keyper/smstate.go
@@ -476,6 +476,11 @@ func (st *ShuttermintState) finalizeDKG(
 		if err != nil {
 			return err
 		}
+		publicKeyBytes, _ := dkgresult.PublicKey.GobEncode()
+		err := queries.InsertEonPublicKey(ctx, kprdb.InsertEonPublicKeyParams{EonPublicKey: publicKeyBytes, Eon: int64(dkgresult.Eon)})
+		if err != nil {
+			return err
+		}
 	}
 
 	return queries.InsertDKGResult(ctx, kprdb.InsertDKGResultParams{

--- a/rolling-shutter/shmsg/gossip.pb.go
+++ b/rolling-shutter/shmsg/gossip.pb.go
@@ -447,6 +447,69 @@ func (x *AggregatedDecryptionSignature) GetSignerBitfield() []byte {
 	return nil
 }
 
+type EonPublicKey struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	InstanceID uint64 `protobuf:"varint,1,opt,name=instanceID,proto3" json:"instanceID,omitempty"`
+	PublicKey  []byte `protobuf:"bytes,2,opt,name=publicKey,proto3" json:"publicKey,omitempty"`
+	Eon        uint64 `protobuf:"varint,3,opt,name=eon,proto3" json:"eon,omitempty"`
+}
+
+func (x *EonPublicKey) Reset() {
+	*x = EonPublicKey{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gossip_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *EonPublicKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EonPublicKey) ProtoMessage() {}
+
+func (x *EonPublicKey) ProtoReflect() protoreflect.Message {
+	mi := &file_gossip_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EonPublicKey.ProtoReflect.Descriptor instead.
+func (*EonPublicKey) Descriptor() ([]byte, []int) {
+	return file_gossip_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *EonPublicKey) GetInstanceID() uint64 {
+	if x != nil {
+		return x.InstanceID
+	}
+	return 0
+}
+
+func (x *EonPublicKey) GetPublicKey() []byte {
+	if x != nil {
+		return x.PublicKey
+	}
+	return nil
+}
+
+func (x *EonPublicKey) GetEon() uint64 {
+	if x != nil {
+		return x.Eon
+	}
+	return 0
+}
+
 var File_gossip_proto protoreflect.FileDescriptor
 
 var file_gossip_proto_rawDesc = []byte{
@@ -507,6 +570,12 @@ var file_gossip_proto_rawDesc = []byte{
 	0x69, 0x67, 0x6e, 0x61, 0x74, 0x75, 0x72, 0x65, 0x12, 0x26, 0x0a, 0x0e, 0x73, 0x69, 0x67, 0x6e,
 	0x65, 0x72, 0x42, 0x69, 0x74, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0c,
 	0x52, 0x0e, 0x73, 0x69, 0x67, 0x6e, 0x65, 0x72, 0x42, 0x69, 0x74, 0x66, 0x69, 0x65, 0x6c, 0x64,
+	0x22, 0x5e, 0x0a, 0x0c, 0x45, 0x6f, 0x6e, 0x50, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x4b, 0x65, 0x79,
+	0x12, 0x1e, 0x0a, 0x0a, 0x69, 0x6e, 0x73, 0x74, 0x61, 0x6e, 0x63, 0x65, 0x49, 0x44, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x04, 0x52, 0x0a, 0x69, 0x6e, 0x73, 0x74, 0x61, 0x6e, 0x63, 0x65, 0x49, 0x44,
+	0x12, 0x1c, 0x0a, 0x09, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x4b, 0x65, 0x79, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x0c, 0x52, 0x09, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x4b, 0x65, 0x79, 0x12, 0x10,
+	0x0a, 0x03, 0x65, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03, 0x65, 0x6f, 0x6e,
 	0x42, 0x0a, 0x5a, 0x08, 0x2e, 0x2f, 0x3b, 0x73, 0x68, 0x6d, 0x73, 0x67, 0x62, 0x06, 0x70, 0x72,
 	0x6f, 0x74, 0x6f, 0x33,
 }
@@ -523,7 +592,7 @@ func file_gossip_proto_rawDescGZIP() []byte {
 	return file_gossip_proto_rawDescData
 }
 
-var file_gossip_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_gossip_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_gossip_proto_goTypes = []interface{}{
 	(*DecryptionTrigger)(nil),             // 0: shmsg.DecryptionTrigger
 	(*DecryptionKeyShare)(nil),            // 1: shmsg.DecryptionKeyShare
@@ -531,6 +600,7 @@ var file_gossip_proto_goTypes = []interface{}{
 	(*CipherBatch)(nil),                   // 3: shmsg.CipherBatch
 	(*DecryptionSignature)(nil),           // 4: shmsg.DecryptionSignature
 	(*AggregatedDecryptionSignature)(nil), // 5: shmsg.AggregatedDecryptionSignature
+	(*EonPublicKey)(nil),                  // 6: shmsg.EonPublicKey
 }
 var file_gossip_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -618,6 +688,18 @@ func file_gossip_proto_init() {
 				return nil
 			}
 		}
+		file_gossip_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*EonPublicKey); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -625,7 +707,7 @@ func file_gossip_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_gossip_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/rolling-shutter/shmsg/gossip.proto
+++ b/rolling-shutter/shmsg/gossip.proto
@@ -45,3 +45,9 @@ message AggregatedDecryptionSignature {
     bytes aggregatedSignature = 4;
     bytes signerBitfield = 5;
 }
+
+message EonPublicKey {
+    uint64 instanceID = 1;
+    bytes publicKey= 2;
+    uint64 eon = 3;
+}

--- a/rolling-shutter/shmsg/messages.go
+++ b/rolling-shutter/shmsg/messages.go
@@ -63,6 +63,13 @@ func (*AggregatedDecryptionSignature) Topic() string {
 	return dcrtopics.AggregatedDecryptionSignature
 }
 
+func (*EonPublicKey) ImplementsP2PMessage() {
+}
+
+func (*EonPublicKey) Topic() string {
+	return kprtopics.EonPublicKey
+}
+
 // NewBatchConfig creates a new BatchConfig message.
 func NewBatchConfig(
 	activationBlockNumber uint64,


### PR DESCRIPTION
I delete the stored eon public key when sending it similar to what `SendShutterMessages` is doing.

I can use two queries (or more) to get the eon keys first and later delete them if you like, but it might prove inconsistent if they are updated in place in the database in between the two queries.