### PR TITLE
Use last batch epochID instead of trigger epochID for next batch

### DIFF
--- a/rolling-shutter/collator/cltrdb/query.sql
+++ b/rolling-shutter/collator/cltrdb/query.sql
@@ -10,14 +10,14 @@ INSERT INTO collator.decryption_trigger (epoch_id, batch_hash) VALUES ($1, $2);
 -- name: GetTrigger :one
 SELECT * FROM collator.decryption_trigger WHERE epoch_id = $1;
 
--- name: GetLastTrigger :one
-SELECT * FROM collator.decryption_trigger ORDER BY epoch_id DESC LIMIT 1;
-
 -- name: InsertBatch :exec
 INSERT INTO collator.cipher_batch (epoch_id, transactions) VALUES ($1, $2);
 
 -- name: GetBatch :one
 SELECT * FROM collator.cipher_batch WHERE epoch_id = $1;
+
+-- name: GetLastBatchEpochID :one
+SELECT epoch_id FROM collator.cipher_batch ORDER BY epoch_id DESC LIMIT 1;
 
 -- name: InsertTx :exec
 INSERT INTO collator.transaction (tx_id, epoch_id, encrypted_tx)VALUES ($1, $2, $3);

--- a/rolling-shutter/collator/cltrdb/query.sqlc.gen.go
+++ b/rolling-shutter/collator/cltrdb/query.sqlc.gen.go
@@ -18,15 +18,15 @@ func (q *Queries) GetBatch(ctx context.Context, epochID []byte) (CollatorCipherB
 	return i, err
 }
 
-const getLastTrigger = `-- name: GetLastTrigger :one
-SELECT epoch_id, batch_hash FROM collator.decryption_trigger ORDER BY epoch_id DESC LIMIT 1
+const getLastBatchEpochID = `-- name: GetLastBatchEpochID :one
+SELECT epoch_id FROM collator.cipher_batch ORDER BY epoch_id DESC LIMIT 1
 `
 
-func (q *Queries) GetLastTrigger(ctx context.Context) (CollatorDecryptionTrigger, error) {
-	row := q.db.QueryRow(ctx, getLastTrigger)
-	var i CollatorDecryptionTrigger
-	err := row.Scan(&i.EpochID, &i.BatchHash)
-	return i, err
+func (q *Queries) GetLastBatchEpochID(ctx context.Context) ([]byte, error) {
+	row := q.db.QueryRow(ctx, getLastBatchEpochID)
+	var epoch_id []byte
+	err := row.Scan(&epoch_id)
+	return epoch_id, err
 }
 
 const getMeta = `-- name: GetMeta :one

--- a/rolling-shutter/collator/epochhandling.go
+++ b/rolling-shutter/collator/epochhandling.go
@@ -23,10 +23,10 @@ func handleEpoch(ctx context.Context, config Config, db *cltrdb.Queries) ([]shms
 }
 
 func makeBatch(ctx context.Context, config Config, db *cltrdb.Queries) (*shmsg.CipherBatch, error) {
-	lastTrigger, err := db.GetLastTrigger(ctx)
 	nextEpochID := uint64(0)
+	lastEpochID, err := db.GetLastBatchEpochID(ctx)
 	if err == nil {
-		nextEpochID = shdb.DecodeUint64(lastTrigger.EpochID) + 1
+		nextEpochID = shdb.DecodeUint64(lastEpochID) + 1
 	} else if err != pgx.ErrNoRows {
 		return nil, err
 	}


### PR DESCRIPTION
The collator would try to store two batches with the same epochID
when killed and restarted in between the time where it stores a
batch and a decryption trigger when using the epochID from a trigger
see https://github.com/shutter-network/rolling-shutter/issues/138