### PR TITLE
Implement basic libp2p peer scoring

### DIFF
--- a/rolling-shutter/p2p/p2p.go
+++ b/rolling-shutter/p2p/p2p.go
@@ -123,7 +123,10 @@ func (p *P2P) createHost(ctx context.Context) error {
 	log.Println("libp2p node address:", p.p2pAddress())
 
 	// create a new PubSub service using the GossipSub router
-	pubSub, err := pubsub.NewGossipSub(ctx, p.host)
+	options := []pubsub.Option{
+		pubsub.WithPeerScore(peerScoreParams(), peerScoreThresholds()),
+	}
+	pubSub, err := pubsub.NewGossipSub(ctx, p.host, options...)
 	if err != nil {
 		return err
 	}
@@ -172,6 +175,12 @@ func (p *P2P) joinTopic(topicName string) error {
 	topic, err := p.pubSub.Join(topicName)
 	if err != nil {
 		return err
+	}
+
+	// set peer scoring parameters
+	err = topic.SetScoreParams(topicScoreParams())
+	if err != nil {
+		return errors.Wrapf(err, "failed to set peer scoring parameters")
 	}
 
 	// and subscribe to it

--- a/rolling-shutter/p2p/params.go
+++ b/rolling-shutter/p2p/params.go
@@ -1,0 +1,66 @@
+package p2p
+
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+func peerScoreParams() *pubsub.PeerScoreParams {
+	return &pubsub.PeerScoreParams{
+		Topics:        make(map[string]*pubsub.TopicScoreParams),
+		TopicScoreCap: 32.72,
+
+		AppSpecificScore:  func(p peer.ID) float64 { return 0 },
+		AppSpecificWeight: 1,
+
+		IPColocationFactorWeight:    0, // -35.11 for non-testing environments
+		IPColocationFactorThreshold: 10,
+		IPColocationFactorWhitelist: nil,
+
+		BehaviourPenaltyWeight:    -15.92,
+		BehaviourPenaltyThreshold: 6,
+		BehaviourPenaltyDecay:     0.928,
+
+		DecayInterval: 12 * time.Second,
+		DecayToZero:   0.01,
+
+		RetainScore: 12 * time.Hour,
+	}
+}
+
+func peerScoreThresholds() *pubsub.PeerScoreThresholds {
+	return &pubsub.PeerScoreThresholds{
+		GossipThreshold:             -4000,
+		PublishThreshold:            -8000,
+		GraylistThreshold:           -16000,
+		AcceptPXThreshold:           100,
+		OpportunisticGraftThreshold: 5,
+	}
+}
+
+func topicScoreParams() *pubsub.TopicScoreParams {
+	// Based on attestation topic in beacon chain network. The formula uses the number of
+	// validators which we set to a fixed number which could be the number of keypers.
+	n := float64(200)
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     1,
+		TimeInMeshWeight:                0.0324,
+		TimeInMeshQuantum:               12 * time.Second,
+		TimeInMeshCap:                   300,
+		FirstMessageDeliveriesWeight:    0.05,
+		FirstMessageDeliveriesDecay:     0.631,
+		FirstMessageDeliveriesCap:       n / 755.712,
+		MeshMessageDeliveriesWeight:     -0.026,
+		MeshMessageDeliveriesDecay:      0.631,
+		MeshMessageDeliveriesCap:        n / 94.464,
+		MeshMessageDeliveriesThreshold:  n / 377.856,
+		MeshMessageDeliveriesWindow:     200 * time.Millisecond,
+		MeshMessageDeliveriesActivation: 4 * 12 * time.Second,
+		MeshFailurePenaltyWeight:        -0.0026,
+		MeshFailurePenaltyDecay:         0.631,
+		InvalidMessageDeliveriesWeight:  -99,
+		InvalidMessageDeliveriesDecay:   0.9994,
+	}
+}


### PR DESCRIPTION
Parameters are taken from what's recommended for the Ethereum beacon chain and/or the Prysm client implementation.

Closes #192 