### PR TITLE
Make deploy scripts re-runable without creating additional tx

### DIFF
--- a/contracts/deploy/100_keypers.js
+++ b/contracts/deploy/100_keypers.js
@@ -3,12 +3,14 @@ const { ethers } = require("hardhat");
 module.exports = async function (hre) {
   const { deployments, getNamedAccounts } = hre;
   const { deployer } = await getNamedAccounts();
-  await deployments.deploy("Keypers", {
+  const deployResult = await deployments.deploy("Keypers", {
     contract: "AddrsSeq",
     from: deployer,
     args: [],
     log: true,
   });
-  const c = await ethers.getContract("Keypers");
-  await c.append();
+  if (deployResult.newlyDeployed) {
+    const c = await ethers.getContract("Keypers");
+    await c.append();
+  }
 };

--- a/contracts/deploy/110_decryptors.js
+++ b/contracts/deploy/110_decryptors.js
@@ -3,12 +3,14 @@ const { ethers } = require("hardhat");
 module.exports = async function (hre) {
   const { deployments, getNamedAccounts } = hre;
   const { deployer } = await getNamedAccounts();
-  await deployments.deploy("Decryptors", {
+  const deployResult = await deployments.deploy("Decryptors", {
     contract: "AddrsSeq",
     from: deployer,
     args: [],
     log: true,
   });
-  const c = await ethers.getContract("Decryptors");
-  await c.append();
+  if (deployResult.newlyDeployed) {
+    const c = await ethers.getContract("Decryptors");
+    await c.append();
+  }
 };

--- a/contracts/deploy/200_collator.js
+++ b/contracts/deploy/200_collator.js
@@ -3,12 +3,14 @@ const { ethers } = require("hardhat");
 module.exports = async function (hre) {
   const { deployments, getNamedAccounts } = hre;
   const { deployer } = await getNamedAccounts();
-  await deployments.deploy("Collator", {
+  const deployResult = await deployments.deploy("Collator", {
     contract: "AddrsSeq",
     from: deployer,
     args: [],
     log: true,
   });
-  const c = await ethers.getContract("Collator");
-  await c.append();
+  if (deployResult.newlyDeployed) {
+    const c = await ethers.getContract("Collator");
+    await c.append();
+  }
 };

--- a/contracts/deploy/510_configure_decryptors.js
+++ b/contracts/deploy/510_configure_decryptors.js
@@ -2,22 +2,51 @@ const { ethers } = require("hardhat");
 
 module.exports = async function (hre) {
   var decryptorAddrs = await hre.getDecryptorAddresses();
+
   const decryptors = await ethers.getContract("Decryptors");
-  const index = await decryptors.count();
-  await decryptors.add(decryptorAddrs);
-  await decryptors.append();
+  const lastSetIndex = (await decryptors.count()) - 1;
+  let configSetIndex;
+
+  let setAdded = true;
+  if (
+    (await decryptors.countNth(lastSetIndex)).toNumber() !==
+    decryptorAddrs.length
+  ) {
+    setAdded = false;
+  } else {
+    for (const i of Array(decryptorAddrs.length).keys()) {
+      if ((await decryptors.at(lastSetIndex, i)) !== decryptorAddrs[i]) {
+        setAdded = false;
+        break;
+      }
+    }
+  }
+  if (setAdded) {
+    console.log("Decryptor set already added");
+    configSetIndex = lastSetIndex;
+  } else {
+    await decryptors.add(decryptorAddrs);
+    await decryptors.append();
+    configSetIndex = lastSetIndex + 1;
+  }
 
   const cfg = await ethers.getContract("DecryptorConfig");
   const currentBlock = await ethers.provider.getBlockNumber();
-  const activationBlock = currentBlock + 10;
+  const activationBlockNumber = currentBlock + 10;
+
+  const activeConfig = await cfg.getActiveConfig(activationBlockNumber);
+  if (activeConfig[1].toNumber() === configSetIndex) {
+    console.log("Decryptor config already added");
+    return;
+  }
 
   await cfg.addNewCfg({
-    activationBlockNumber: activationBlock,
-    setIndex: index,
+    activationBlockNumber: activationBlockNumber,
+    setIndex: configSetIndex,
   });
   console.log(
     "configure decryptors: activationBlockNumber %s decryptors: %s",
-    activationBlock,
+    activationBlockNumber,
     decryptorAddrs
   );
 };

--- a/contracts/deploy/515_configure_collator.js
+++ b/contracts/deploy/515_configure_collator.js
@@ -1,23 +1,52 @@
 const { ethers } = require("hardhat");
 
 module.exports = async function (hre) {
-  var collatorAddress = await hre.getCollatorAddress();
+  var collatorAddress = [await hre.getCollatorAddress()];
+
   const collator = await ethers.getContract("Collator");
-  const index = await collator.count();
-  await collator.add([collatorAddress]);
-  await collator.append();
+  const lastSetIndex = (await collator.count()) - 1;
+  let configSetIndex;
+
+  let setAdded = true;
+  if (
+    (await collator.countNth(lastSetIndex)).toNumber() !==
+    collatorAddress.length
+  ) {
+    setAdded = false;
+  } else {
+    for (const i of Array(collatorAddress.length).keys()) {
+      if ((await collator.at(lastSetIndex, i)) !== collatorAddress[i]) {
+        setAdded = false;
+        break;
+      }
+    }
+  }
+  if (setAdded) {
+    console.log("Collator set already added");
+    configSetIndex = lastSetIndex;
+  } else {
+    await collator.add(collatorAddress);
+    await collator.append();
+    configSetIndex = lastSetIndex + 1;
+  }
 
   const cfg = await ethers.getContract("CollatorConfig");
   const currentBlock = await ethers.provider.getBlockNumber();
-  const activationBlock = currentBlock + 10;
+  const activationBlockNumber = currentBlock + 10;
+
+  const activeConfig = await cfg.getActiveConfig(activationBlockNumber);
+  if (activeConfig[1].toNumber() === configSetIndex) {
+    console.log("Collator config already added");
+    return;
+  }
 
   await cfg.addNewCfg({
-    activationBlockNumber: activationBlock,
-    setIndex: index,
+    activationBlockNumber: activationBlockNumber,
+    setIndex: configSetIndex,
   });
   console.log(
     "configure collator: activationBlockNumber %s collator: %s",
-    activationBlock,
-    collatorAddress
+    activationBlockNumber,
+    ...collatorAddress
   );
 };

--- a/contracts/deploy/520_fund.js
+++ b/contracts/deploy/520_fund.js
@@ -1,4 +1,5 @@
 const { ethers } = require("hardhat");
+const { BigNumber } = require("ethers");
 
 module.exports = async function (hre) {
   const fundValue = hre.deployConf.fundValue;
@@ -20,6 +21,12 @@ module.exports = async function (hre) {
 
   const txs = [];
   for (const a of addresses) {
+    const balance = await ethers.provider.getBalance(a);
+    const weiFund = ethers.utils.parseEther(fundValue);
+    if (balance.gt(BigNumber.from(weiFund))) {
+      console.log(a + " already funded");
+      continue;
+    }
     const tx = await owner.sendTransaction({
       to: a,
       value: value,


### PR DESCRIPTION
You can still run `npx hardhat node` and it will deploy everything
and set the proper sets and configs.

closes https://github.com/shutter-network/rolling-shutter/issues/197