### PR TITLE
Update txtypes version to v0.0.4

### DIFF
--- a/rolling-shutter/collator/batch/batch.go
+++ b/rolling-shutter/collator/batch/batch.go
@@ -229,7 +229,7 @@ func (b *Batch) SignedBatchTx(privateKey *ecdsa.PrivateKey, decryptionKey []byte
 		ChainID:       b.ChainID,
 		DecryptionKey: decryptionKey,
 		BatchIndex:    batchIndex,
-		L1BlockNumber: new(big.Int).SetUint64(b.l1BlockNumber),
+		L1BlockNumber: b.l1BlockNumber,
 		Timestamp:     big.NewInt(ts),
 		Transactions:  txs.Bytes(),
 	}

--- a/rolling-shutter/go.mod
+++ b/rolling-shutter/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/rs/zerolog v1.26.1
 	github.com/shutter-network/shutter/shlib v0.1.10
-	github.com/shutter-network/txtypes v0.0.3
+	github.com/shutter-network/txtypes v0.0.4
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.11.0

--- a/rolling-shutter/go.sum
+++ b/rolling-shutter/go.sum
@@ -1706,8 +1706,8 @@ github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYED
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/shutter-network/shutter/shlib v0.1.10 h1:p0O35mZBHqDD/UXTMYh6GtKtPCG7kv0b7DWpMNYOXrE=
 github.com/shutter-network/shutter/shlib v0.1.10/go.mod h1:V003agcyGtHXQT0yIe3xmvN6AYfqSpnJPnHCwmiLzF8=
-github.com/shutter-network/txtypes v0.0.3 h1:f4RkXmx2pyCNvQMFcdK/h8S2ZHeQtBdj2Xd5OpUrlMU=
-github.com/shutter-network/txtypes v0.0.3/go.mod h1:OojGWxGTcroGInvhbux+FgRw82pHehftrQYZIgeywos=
+github.com/shutter-network/txtypes v0.0.4 h1:44vSCcmePg62f9b3eePtXEuqv0cH3nMyC5bc0o/5Gm8=
+github.com/shutter-network/txtypes v0.0.4/go.mod h1:OojGWxGTcroGInvhbux+FgRw82pHehftrQYZIgeywos=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
This version adds a L1BlockNumber field to shutter txs. For some reason I forgot to create a PR.