### PR TITLE
Fix L1/L2 block numbers

### DIFF
--- a/play/src/sht/play.clj
+++ b/play/src/sht/play.clj
@@ -159,7 +159,8 @@
                               "DKGPhaseLength" 8
                               "ListenAddress" (format "/ip4/127.0.0.1/tcp/%d" p2p-port)
                               "HTTPEnabled" true
-                              "HTTPListenAddress" (format ":%d" (+ 24000 n))}}))
+                              "HTTPListenAddress" (format ":%d" (+ 24000 n))
+                              "L2URL" "http://127.0.0.1:8545/"}}))
 
 ;; -- mocknode-subcommand
 (defn mocknode-subcommand

--- a/rolling-shutter/cmd/keyper/keyper.go
+++ b/rolling-shutter/cmd/keyper/keyper.go
@@ -179,6 +179,7 @@ func exampleConfig() (*keyper.Config, error) {
 	cfg := &keyper.Config{
 		ShuttermintURL:     "http://localhost:26657",
 		EthereumURL:        "http://127.0.0.1:8545/",
+		L2URL:              "http://127.0.0.1:8547/",
 		DeploymentDir:      "./deployments/localhost/",
 		DKGPhaseLength:     30,
 		DKGStartBlockDelta: 12000,

--- a/rolling-shutter/keyper/config.go
+++ b/rolling-shutter/keyper/config.go
@@ -23,6 +23,7 @@ import (
 type Config struct {
 	ShuttermintURL string
 	EthereumURL    string
+	L2URL          string
 	DatabaseURL    string
 	DeploymentDir  string
 
@@ -47,6 +48,7 @@ const configTemplate = `# Shutter keyper config
 
 ShuttermintURL		= "{{ .ShuttermintURL }}"
 EthereumURL         = "{{ .EthereumURL }}"
+L2URL               = "{{ .L2URL }}"
 DeploymentDir       = "{{ .DeploymentDir }}"
 
 # DatabaseURL looks like postgres://username:password@localhost:5432/database_name


### PR DESCRIPTION
Closes #301 

The contracts are deployed on L2, but we use the L1 block number as a clock. Two changes:

1) Collator: Expect the contracts to be deployed on the rollup (to which we're connected via `SequencerURL`). Get block numbers for batches from `EthereumURL`.
2) Keyper: Add an L2 node URL as additional config option. Get contracts from there and block numbers from `EthereumURL`. For `BlockSeen` messages, fetch block numbers from `EthereumURL` (instead of using `NextBlock` from the chain observer, which observes the L2 chain).

For simplicity of the testing infrastructure, we use the same node as L1 and L2.