### PR TITLE
Adjust deployment to support nitro

### DIFF
--- a/contracts/deploy/090_fund.js
+++ b/contracts/deploy/090_fund.js
@@ -8,9 +8,16 @@ module.exports = async function (hre) {
     return;
   }
 
-  const [owner] = await ethers.getSigners();
-  const keypers = await hre.getKeyperAddresses();
-  const addresses = keypers;
+  const { bank, deployer } = await hre.getNamedAccounts();
+  const bankSigner = await ethers.getSigner(bank);
+
+  let addresses = [];
+  if (deployer !== bank) {
+    addresses.push(deployer);
+  }
+  addresses.push(...(await hre.getKeyperAddresses()));
+  addresses.push(await hre.getCollatorAddress());
+
   const value = ethers.utils.parseEther(fundValue);
   console.log(
     "fund: funding %s adresses with %s eth",
@@ -26,7 +33,7 @@ module.exports = async function (hre) {
       console.log(a + " already funded");
       continue;
     }
-    const tx = await owner.sendTransaction({
+    const tx = await bankSigner.sendTransaction({
       to: a,
       value: value,
     });

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -68,6 +68,11 @@ module.exports = {
     keyper1: 2,
     keyper2: 3,
     collator: 7,
+    bank: {
+      // an account that has funds
+      default: 0,
+      nitro: 1,
+    },
   },
   networks: {
     hardhat: {
@@ -76,13 +81,12 @@ module.exports = {
         interval: 1500,
       },
     },
-    optimistic: {
-      url: "http://127.0.0.1:8545",
-      accounts: {
-        mnemonic: "test test test test test test test test test test test junk",
-      },
-      gasPrice: 15000000,
-      ovm: true, // This sets the network as using the ovm and ensure contract will be compiled against that.
+    nitro: {
+      url: "http://localhost:8547",
+      accounts: [
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", // first hardhat acccount
+        "0xe887f7d17d07cc7b8004053fb8826f6657084e88904bb61590e498ca04704cf2", // nitro funnel
+      ],
     },
   },
 };


### PR DESCRIPTION
On a fresh nitro instance, the deployer account has no funds. This
commit therefore allows configuring an arbitrary `bank` account that has
funds. The funding deploy task will fund collator, keypers, and deployer
from that account.

Also, the fund step is now run before all other deployment steps.