### PR TITLE
Some shcrypto js changes

### DIFF
--- a/js/shutter-crypto/Makefile
+++ b/js/shutter-crypto/Makefile
@@ -6,9 +6,13 @@ TINYGO    ?= tinygo
 
 build: derive
 	${NPX} webpack build
+	cp -L derived/shutter-crypto.wasm dist/
 
 publish: build
 	${NPM} publish --access=public --tag=beta
+
+pack: build
+	${NPM} pack
 
 derive: derived/shutter-crypto.wasm derived/wasm_exec.js
 

--- a/js/shutter-crypto/README.md
+++ b/js/shutter-crypto/README.md
@@ -13,19 +13,26 @@ npm install @shutter-network/shutter-crypto@beta
 
 The module provides the following public functions:
 
-### `shutterCrypto.init()`
+### `async shutterCrypto.init(wasmUrlOrPath)`
 
 Load and initialize the Go wasm library. This Promise needs to be consumed
 before any other function in the library is called.
 
-### `shutterCrypto.encrypt(message, eonPublicKey, epochId, sigma)`
+On Node the `wasmUrlOrPath` parameter is optional. If not given it will be
+determined automatically.
+
+In a Web context the path to the `shutter-crypto.wasm` file needs to be given
+(since it appears no standard cross framework way of automatically determining a
+path is available).
+
+### `async shutterCrypto.encrypt(message, eonPublicKey, epochId, sigma)`
 
 ...
 
-### `shutterCrypto.decrypt(encryptedMessage, decryptionKey)`
+### `async shutterCrypto.decrypt(encryptedMessage, decryptionKey)`
 
 ...
 
-### `shutterCrypto.verifyDecryptionKey(decryptionKey, eonPublicKey, epochId)`
+### `async shutterCrypto.verifyDecryptionKey(decryptionKey, eonPublicKey, epochId)`
 
 ...

--- a/js/shutter-crypto/package-lock.json
+++ b/js/shutter-crypto/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shutter-network/shutter-crypto",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shutter-network/shutter-crypto",
-      "version": "0.1.0-beta.2",
+      "version": "0.1.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "browser-or-node": "^2.0.0"

--- a/js/shutter-crypto/package.json
+++ b/js/shutter-crypto/package.json
@@ -21,9 +21,16 @@
     ],
     "parserOptions": {
       "sourceType": "module"
+    },
+    "env": {
+      "browser": true,
+      "node": true
     }
   },
   "dependencies": {
     "browser-or-node": "^2.0.0"
+  },
+  "scripts": {
+    "prepare": "cp -L derived/shutter-crypto.wasm dist"
   }
 }

--- a/js/shutter-crypto/package.json
+++ b/js/shutter-crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shutter-network/shutter-crypto",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "Core crypto primitives to interact with Shutter Network",
   "author": "Shutter Network <contact@shutter.network>",
   "license": "MIT",

--- a/js/shutter-crypto/src/index.js
+++ b/js/shutter-crypto/src/index.js
@@ -43,28 +43,57 @@ function _checkInitialized() {
   }
 }
 
+function _throwOnError(result) {
+  if (result.startsWith("Error:")) {
+    throw result;
+  }
+}
+
+function _hexToUint8Array(hex) {
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+  if (hex.length % 2 != 0) {
+    hex = "0" + hex;
+  }
+  let bytes = [];
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes.push(parseInt(hex.substring(i, i + 2), 16));
+  }
+  return Uint8Array.from(bytes);
+}
+
 async function encrypt(message, eonPublicKey, epochId, sigma) {
   _checkInitialized();
-  return await g.__wasm_functions__.encrypt(
+  const result = await g.__wasm_functions__.encrypt(
     message,
     eonPublicKey,
     epochId,
     sigma
   );
+  _throwOnError(result);
+  return _hexToUint8Array(result);
 }
 
 async function decrypt(encryptedMessage, decryptionKey) {
   _checkInitialized();
-  return await g.__wasm_functions__.decrypt(encryptedMessage, decryptionKey);
+  const result = await g.__wasm_functions__.decrypt(
+    encryptedMessage,
+    decryptionKey
+  );
+  _throwOnError(result);
+  return _hexToUint8Array(result);
 }
 
 async function verifyDecryptionKey(decryptionKey, eonPublicKey, epochId) {
   _checkInitialized();
-  return await g.__wasm_functions__.verifyDecryptionKey(
+  const result = await g.__wasm_functions__.verifyDecryptionKey(
     decryptionKey,
     eonPublicKey,
     epochId
   );
+  _throwOnError(result);
+  return result;
 }
 
 export { init, encrypt, decrypt, verifyDecryptionKey };

--- a/js/shutter-crypto/src/index.js
+++ b/js/shutter-crypto/src/index.js
@@ -6,6 +6,7 @@ if (typeof g.__wasm_functions__ === "undefined") {
   g.__wasm_functions__ = {};
 }
 
+const defaultWasmFileName = "shutter-crypto.wasm";
 async function init(wasmUrlOrPath) {
   let shutterCrypto;
   const go = new Go(); // eslint-disable-line no-undef
@@ -26,6 +27,10 @@ async function init(wasmUrlOrPath) {
     }
   } else if (isNode) {
     const fs = __non_webpack_require__("fs"); // eslint-disable-line no-undef
+    const path = __non_webpack_require__("path"); // eslint-disable-line no-undef
+    if (wasmUrlOrPath === undefined) {
+      wasmUrlOrPath = path.join(__dirname, defaultWasmFileName);
+    }
     const obj = await WebAssembly.instantiate(
       fs.readFileSync(wasmUrlOrPath),
       go.importObject

--- a/js/shutter-crypto/src/index.js
+++ b/js/shutter-crypto/src/index.js
@@ -6,37 +6,32 @@ if (typeof g.__wasm_functions__ === "undefined") {
   g.__wasm_functions__ = {};
 }
 
-function init(wasmUrlOrPath) {
+async function init(wasmUrlOrPath) {
   let shutterCrypto;
   const go = new Go(); // eslint-disable-line no-undef
   if (isBrowser) {
     if ("instantiateStreaming" in WebAssembly) {
-      return WebAssembly.instantiateStreaming(
+      const obj = await WebAssembly.instantiateStreaming(
         fetch(wasmUrlOrPath),
         go.importObject
-      ).then((obj) => {
-        shutterCrypto = obj.instance;
-        go.run(shutterCrypto);
-      });
+      );
+      shutterCrypto = obj.instance;
+      go.run(shutterCrypto);
     } else {
-      return fetch(wasmUrlOrPath)
-        .then((resp) => resp.arrayBuffer())
-        .then((bytes) =>
-          WebAssembly.instantiate(bytes, go.importObject).then((obj) => {
-            shutterCrypto = obj.instance;
-            go.run(shutterCrypto);
-          })
-        );
+      const resp = await fetch(wasmUrlOrPath);
+      const bytes = await resp.arrayBuffer();
+      const obj = WebAssembly.instantiate(bytes, go.importObject);
+      shutterCrypto = obj.instance;
+      go.run(shutterCrypto);
     }
   } else if (isNode) {
     const fs = __non_webpack_require__("fs"); // eslint-disable-line no-undef
-    WebAssembly.instantiate(
+    const obj = await WebAssembly.instantiate(
       fs.readFileSync(wasmUrlOrPath),
       go.importObject
-    ).then((obj) => {
-      shutterCrypto = obj.instance;
-      go.run(shutterCrypto);
-    });
+    );
+    shutterCrypto = obj.instance;
+    go.run(shutterCrypto);
   } else {
     throw "Neither Browser nor Node; not supported.";
   }
@@ -48,19 +43,24 @@ function _checkInitialized() {
   }
 }
 
-function encrypt(message, eonPublicKey, epochId, sigma) {
+async function encrypt(message, eonPublicKey, epochId, sigma) {
   _checkInitialized();
-  return g.__wasm_functions__.encrypt(message, eonPublicKey, epochId, sigma);
+  return await g.__wasm_functions__.encrypt(
+    message,
+    eonPublicKey,
+    epochId,
+    sigma
+  );
 }
 
-function decrypt(encryptedMessage, decryptionKey) {
+async function decrypt(encryptedMessage, decryptionKey) {
   _checkInitialized();
-  return g.__wasm_functions__.decrypt(encryptedMessage, decryptionKey);
+  return await g.__wasm_functions__.decrypt(encryptedMessage, decryptionKey);
 }
 
-function verifyDecryptionKey(decryptionKey, eonPublicKey, epochId) {
+async function verifyDecryptionKey(decryptionKey, eonPublicKey, epochId) {
   _checkInitialized();
-  return g.__wasm_functions__.verifyDecryptionKey(
+  return await g.__wasm_functions__.verifyDecryptionKey(
     decryptionKey,
     eonPublicKey,
     epochId

--- a/js/shutter-crypto/src/index.js
+++ b/js/shutter-crypto/src/index.js
@@ -1,57 +1,25 @@
 import "../derived/wasm_exec";
 import { isBrowser, isNode } from "browser-or-node";
 
-let wasm = require("../derived/shutter-crypto.wasm");
-
 const g = global || window || this || self;
 if (typeof g.__wasm_functions__ === "undefined") {
   g.__wasm_functions__ = {};
 }
 
-/* global Go, __non_webpack_require__, __dirname, __webpack_require__ */
-
-/* Slightly modified copy from webpack/runtime/publicPath
- * Webpack's automatic publicPath doesn't work in node, so we need to manually
- * handle it to be compatible with both.
- */
-function getScriptUrl() {
-  var scriptUrl;
-  if (__webpack_require__.g.importScripts)
-    scriptUrl = __webpack_require__.g.location + "";
-  var document = __webpack_require__.g.document;
-  if (!scriptUrl && document) {
-    if (document.currentScript) scriptUrl = document.currentScript.src;
-    if (!scriptUrl) {
-      var scripts = document.getElementsByTagName("script");
-      if (scripts.length) scriptUrl = scripts[scripts.length - 1].src;
-    }
-  }
-  // When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration
-  // or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.
-  if (!scriptUrl)
-    throw new Error("Automatic publicPath is not supported in this browser");
-  scriptUrl = scriptUrl
-    .replace(/#.*$/, "")
-    .replace(/\?.*$/, "")
-    .replace(/\/[^/]+$/, "/");
-  return scriptUrl;
-}
-
-function init() {
+function init(wasmUrlOrPath) {
   let shutterCrypto;
-  const go = new Go();
+  const go = new Go(); // eslint-disable-line no-undef
   if (isBrowser) {
-    wasm = getScriptUrl() + wasm;
     if ("instantiateStreaming" in WebAssembly) {
       return WebAssembly.instantiateStreaming(
-        fetch(wasm),
+        fetch(wasmUrlOrPath),
         go.importObject
       ).then((obj) => {
         shutterCrypto = obj.instance;
         go.run(shutterCrypto);
       });
     } else {
-      return fetch(wasm)
+      return fetch(wasmUrlOrPath)
         .then((resp) => resp.arrayBuffer())
         .then((bytes) =>
           WebAssembly.instantiate(bytes, go.importObject).then((obj) => {
@@ -61,10 +29,9 @@ function init() {
         );
     }
   } else if (isNode) {
-    const fs = __non_webpack_require__("fs");
-    const path = __non_webpack_require__("path");
+    const fs = __non_webpack_require__("fs"); // eslint-disable-line no-undef
     WebAssembly.instantiate(
-      fs.readFileSync(path.join(__dirname, wasm)),
+      fs.readFileSync(wasmUrlOrPath),
       go.importObject
     ).then((obj) => {
       shutterCrypto = obj.instance;

--- a/js/shutter-crypto/webpack.config.js
+++ b/js/shutter-crypto/webpack.config.js
@@ -18,11 +18,17 @@ module.exports = {
     },
   },
   module: {
-    noParse: /wasm_exec.js/,
     rules: [{ test: /\.wasm$/, type: "asset" }],
   },
   node: {
     // Disable mangling node's `__dirname` property since we need it to load the WASM file
     __dirname: false,
+  },
+  resolve: {
+    fallback: {
+      fs: false,
+      crypto: false,
+      util: false,
+    },
   },
 };

--- a/js/shutter-crypto/webpack.config.js
+++ b/js/shutter-crypto/webpack.config.js
@@ -11,6 +11,10 @@ module.exports = {
       type: "umd",
     },
   },
+  node: {
+    // Disable mangling node's `__dirname` property since we need it to load the WASM file
+    __dirname: false,
+  },
   resolve: {
     fallback: {
       fs: false,

--- a/js/shutter-crypto/webpack.config.js
+++ b/js/shutter-crypto/webpack.config.js
@@ -1,28 +1,15 @@
 const path = require("path");
 
-/* global __dirname */
-
 module.exports = {
   mode: "production",
-  performance: {
-    maxAssetSize: 350_000,
-  },
   output: {
     path: path.resolve(__dirname, "dist"),
     filename: "shutter-crypto.js",
-    publicPath: "",
     globalObject: "this",
     library: {
       name: "shutterCrypto",
       type: "umd",
     },
-  },
-  module: {
-    rules: [{ test: /\.wasm$/, type: "asset" }],
-  },
-  node: {
-    // Disable mangling node's `__dirname` property since we need it to load the WASM file
-    __dirname: false,
   },
   resolve: {
     fallback: {

--- a/rolling-shutter/shcryptowasm/shutter_crypto_wasm.go
+++ b/rolling-shutter/shcryptowasm/shutter_crypto_wasm.go
@@ -12,21 +12,25 @@ import (
 var (
 	uint8Array        js.Value
 	uint8ClampedArray js.Value
-	functionRegistry  js.Value
+	jsRegistry        js.Value
 )
 
 const (
-	registryJavaScriptName = "__wasm_functions__"
+	registryJavaScriptName = "__wasm_bridge__"
+	initializedPromiseName = "_initialized"
 )
 
 func main() {
 	uint8Array = js.Global().Get("Uint8Array")
 	uint8ClampedArray = js.Global().Get("Uint8ClampedArray")
-	functionRegistry = js.Global().Get(registryJavaScriptName)
+	jsRegistry = js.Global().Get(registryJavaScriptName)
 
-	functionRegistry.Set("encrypt", encrypt)
-	functionRegistry.Set("decrypt", decrypt)
-	functionRegistry.Set("verifyDecryptionKey", verifyDecryptionKey)
+	jsRegistry.Set("encrypt", encrypt)
+	jsRegistry.Set("decrypt", decrypt)
+	jsRegistry.Set("verifyDecryptionKey", verifyDecryptionKey)
+
+	// Tell JS we're loaded
+	jsRegistry.Get(initializedPromiseName).Invoke()
 
 	select {}
 }


### PR DESCRIPTION
- Users have to specify URL/path to the WASM file. This seems to be the most flexible, but requires some manual work on the users side. On node could look something like this: `await shutterCrypto.init("./node_modules/@shutter-network/shutter-crypto")`. For frontends, users can first `ln -s node_modules/@shutter-network/shutter-crypto/dist/shutter-crypto.wasm public` and then initialize with `await shutterCrypto.init("shutter-crypto.wasm")`. This seems acceptable to me. I failed to find a more automatic way to do it.
- functions are explicitly async
- errors returned from WASM are thrown as exceptions
- return values are converted from hex to Uint8Array (same format as inputs are expected)

Builds on top of #308 