### PR TITLE
`batch` package split and threadsafety improvements

### DIFF
--- a/.circleci/rolling-shutter.yml
+++ b/.circleci/rolling-shutter.yml
@@ -74,7 +74,7 @@ jobs:
           name: "Run unit tests with gotestsum"
           command: |
             mkdir -p report/unit report/integration
-            gotestsum -f standard-verbose --junitfile report/unit/tests.xml -- -short ./...
+            gotestsum -f standard-verbose --junitfile report/unit/tests.xml -- -short -race ./...
       - run:
           name: Wait for PostgreSQL
           command: |
@@ -84,7 +84,7 @@ jobs:
       - run:
           name: "Run integration tests with gotestsum"
           command: |
-            gotestsum -f standard-verbose --junitfile report/integration/tests.xml -- -p 1 -run Integration -count=1 ./...
+            gotestsum -f standard-verbose --junitfile report/integration/tests.xml -- -race -p 1 -run Integration -count=1 ./...
       - store_test_results:
           path: report
       - save_cache:

--- a/rolling-shutter/Makefile
+++ b/rolling-shutter/Makefile
@@ -26,11 +26,11 @@ protoc:
 
 test-unit:
 	@echo "====================> Running unit tests"
-	gotestsum -- -short ${GOFLAGS} ./...
+	gotestsum -- -race -short ${GOFLAGS} ./...
 
 test-integration:
 	@echo "====================>  Running integration tests"
-	gotestsum -- -p 1 -run Integration -count=1 ${GOFLAGS} ./...
+	gotestsum -- -race -p 1 -run Integration -count=1 ${GOFLAGS} ./...
 
 test: test-unit
 

--- a/rolling-shutter/collator/batchhandler/batch/batch.go
+++ b/rolling-shutter/collator/batchhandler/batch/batch.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -90,7 +89,7 @@ func NewCachedPendingBatch(
 		signer:        signer,
 		state:         state,
 		block:         block,
-		transactions:  transaction.NewTransactionQueue(),
+		transactions:  transaction.NewQueue(),
 	}
 	b.gasPool.AddGas(block.GasLimit())
 	return b, nil
@@ -111,7 +110,7 @@ type Batch struct {
 	block        sequencer.Block
 	signer       txtypes.Signer
 	state        sequencer.State
-	transactions *transaction.TransactionQueue
+	transactions *transaction.Queue
 
 	epochID       epochid.EpochID
 	l1BlockNumber uint64
@@ -198,7 +197,7 @@ func (b *Batch) ApplyTx(ctx context.Context, p *transaction.Pending) error {
 	return nil
 }
 
-func (b *Batch) Transactions() *transaction.TransactionQueue {
+func (b *Batch) Transactions() *transaction.Queue {
 	return b.transactions
 }
 

--- a/rolling-shutter/collator/batchhandler/batch/batch.go
+++ b/rolling-shutter/collator/batchhandler/batch/batch.go
@@ -81,13 +81,12 @@ func NewCachedPendingBatch(
 	if err != nil {
 		return nil, err
 	}
-	state := sequencer.NewChainBatchCache(client, nil)
 	b := &Batch{
 		ChainID:       chainID,
 		epochID:       epochID,
 		l1BlockNumber: l1BlockNumber,
 		signer:        signer,
-		state:         state,
+		state:         sequencer.NewCached(client, nil),
 		block:         block,
 		transactions:  transaction.NewQueue(),
 	}

--- a/rolling-shutter/collator/batchhandler/sequencer/mockethserver.go
+++ b/rolling-shutter/collator/batchhandler/sequencer/mockethserver.go
@@ -1,4 +1,4 @@
-package batch
+package sequencer
 
 import (
 	"encoding/json"

--- a/rolling-shutter/collator/batchhandler/sequencer/mockethserver.go
+++ b/rolling-shutter/collator/batchhandler/sequencer/mockethserver.go
@@ -74,19 +74,18 @@ type txHookFunc func(me *MockEthServer, tx *txtypes.Transaction) bool
 // The functionality of the MockEthServer is based on the
 // needs in the tests and might be extented in the future.
 type MockEthServer struct {
-	Mux            sync.RWMutex
-	URL            string
-	t              *testing.T
-	balances       map[string]map[string]*big.Int
-	nonces         map[string]map[string]uint64
-	chainID        *big.Int
-	blocks         map[string]blockData
-	blockNumber    uint64
-	receivedTxs    map[string]bool
-	HTTPServer     *httptest.Server
-	txs            map[string]*txtypes.Transaction
-	hooks          []txHookFunc
-	previousTxHash string
+	Mux         sync.RWMutex
+	URL         string
+	t           *testing.T
+	balances    map[string]map[string]*big.Int
+	nonces      map[string]map[string]uint64
+	chainID     *big.Int
+	blocks      map[string]blockData
+	blockNumber uint64
+	receivedTxs map[string]bool
+	HTTPServer  *httptest.Server
+	txs         map[string]*txtypes.Transaction
+	hooks       []txHookFunc
 }
 
 // Teardown has to be called if the MockEthServer is run

--- a/rolling-shutter/collator/batchhandler/sequencer/mockethserver_test.go
+++ b/rolling-shutter/collator/batchhandler/sequencer/mockethserver_test.go
@@ -10,10 +10,26 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"gotest.tools/assert"
+
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/config"
 )
 
+func newTestConfig(t *testing.T) config.Config {
+	t.Helper()
+
+	ethereumKey, err := ethcrypto.GenerateKey()
+	assert.NilError(t, err)
+	return config.Config{
+		EthereumURL:         "http://127.0.0.1:8454",
+		SequencerURL:        "http://127.0.0.1:8455",
+		EthereumKey:         ethereumKey,
+		ExecutionBlockDelay: uint32(5),
+		InstanceID:          123,
+	}
+}
+
 func TestMockEth(t *testing.T) {
-	config := newTestConfig(t)
+	cfg := newTestConfig(t)
 	eth := RunMockEthServer(t)
 	defer eth.Teardown()
 
@@ -22,7 +38,7 @@ func TestMockEth(t *testing.T) {
 	ctx := context.Background()
 	ethClient := ethclient.NewClient(rpcClient)
 
-	address := ethcrypto.PubkeyToAddress(config.EthereumKey.PublicKey)
+	address := ethcrypto.PubkeyToAddress(cfg.EthereumKey.PublicKey)
 	balance := big.NewInt(42)
 	nonce := uint64(42)
 	chainID := big.NewInt(0)

--- a/rolling-shutter/collator/batchhandler/sequencer/mockethserver_test.go
+++ b/rolling-shutter/collator/batchhandler/sequencer/mockethserver_test.go
@@ -1,4 +1,4 @@
-package batch
+package sequencer
 
 import (
 	"context"

--- a/rolling-shutter/collator/batchhandler/sequencer/statecache.go
+++ b/rolling-shutter/collator/batchhandler/sequencer/statecache.go
@@ -3,6 +3,9 @@ package sequencer
 import (
 	"context"
 	"math/big"
+	"reflect"
+	"sync"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
@@ -27,26 +30,89 @@ type EthClient interface {
 	NonceAt(context.Context, common.Address, *big.Int) (uint64, error)
 }
 
-func NewChainBatchCache(client EthClient, atBlockNumber *big.Int) *ChainBatchCache {
-	return &ChainBatchCache{
+type countedMux struct {
+	mux *sync.RWMutex
+	cnt uint32
+}
+
+func NewKeyedMutex[T comparable]() *KeyedMutex[T] {
+	return &KeyedMutex[T]{mu: sync.RWMutex{}, muxs: make(map[T]*countedMux)}
+}
+
+type KeyedMutex[T comparable] struct {
+	mu   sync.RWMutex
+	muxs map[T]*countedMux
+}
+
+func (ml *KeyedMutex[T]) call(method string, v T, delta int) {
+	ml.mu.Lock()
+	vmu, ok := ml.muxs[v]
+	if !ok {
+		vmu = &countedMux{
+			mux: &sync.RWMutex{},
+			cnt: 0,
+		}
+		ml.muxs[v] = vmu
+	}
+	var addUint32 uint32
+	if delta < 0 {
+		// recommended operation to substract from counter
+		addUint32 = ^uint32((-delta) - 1)
+	} else {
+		addUint32 = uint32(delta)
+	}
+	atomic.AddUint32(&vmu.cnt, addUint32)
+	ml.mu.Unlock()
+	// e.g. for method="Lock", this translates to:
+	// vmu.mux.Lock()
+	reflect.ValueOf(vmu.mux).MethodByName(method).Call([]reflect.Value{})
+	ml.mu.Lock()
+	if vmu.cnt <= 0 {
+		delete(ml.muxs, v)
+	}
+	ml.mu.Unlock()
+}
+
+func (ml *KeyedMutex[T]) Lock(v T) {
+	ml.call("Lock", v, 1)
+}
+
+func (ml *KeyedMutex[T]) Unlock(v T) {
+	ml.call("Unlock", v, -1)
+}
+
+func (ml *KeyedMutex[T]) RLock(v T) {
+	ml.call("RLock", v, 1)
+}
+
+func (ml *KeyedMutex[T]) RUnlock(v T) {
+	ml.call("RUnlock", v, -1)
+}
+
+func NewCached(client EthClient, atBlockNumber *big.Int) *Cached {
+	return &Cached{
+		balances:      make(map[common.Address]*big.Int),
+		nonces:        make(map[common.Address]uint64),
+		balancesLocks: NewKeyedMutex[common.Address](),
+		noncesLocks:   NewKeyedMutex[common.Address](),
 		Client:        client,
-		AtBlockNumber: nil,
-		balances:      make(map[common.Address]*big.Int, 0),
-		nonces:        make(map[common.Address]uint64, 0),
+		AtBlockNumber: atBlockNumber,
 	}
 }
 
-// ChainBatchCache tracks the state of account's nonces and balances
+// Cached tracks the state of account's nonces and balances
 // for a certain Batch.
 // If an address is not cached yet, it polls initial balances or nonces
 // on a GetBalance or GetNonce call from the underlying ethereum node via the
-// ChainBatchCache.Client. Then the value is cached and never polled again for
+// Cached.Client. Then the value is cached and never polled again for
 // that address.
 // This allows to poll chain-state and then modify it locally, e.g. while
 // accepting user transactions to be proposed as the next block to the sequencer.
-type ChainBatchCache struct {
-	balances map[common.Address]*big.Int
-	nonces   map[common.Address]uint64
+type Cached struct {
+	balances      map[common.Address]*big.Int
+	nonces        map[common.Address]uint64
+	balancesLocks *KeyedMutex[common.Address]
+	noncesLocks   *KeyedMutex[common.Address]
 
 	Client        EthClient
 	AtBlockNumber *big.Int
@@ -54,7 +120,14 @@ type ChainBatchCache struct {
 
 // GetBalance polls and caches the state of account `a` balance at the
 // block number ChainBatchCache.AtBlockNumber.
-func (c *ChainBatchCache) GetBalance(ctx context.Context, a common.Address) (*big.Int, error) {
+func (c *Cached) GetBalance(ctx context.Context, a common.Address) (*big.Int, error) {
+	// write lock because we eventually write to the dict
+	c.balancesLocks.Lock(a)
+	defer c.balancesLocks.Unlock(a)
+	return c.getBalance(ctx, a)
+}
+
+func (c *Cached) getBalance(ctx context.Context, a common.Address) (*big.Int, error) {
 	var err error
 
 	bal, exists := c.balances[a]
@@ -72,8 +145,14 @@ func (c *ChainBatchCache) GetBalance(ctx context.Context, a common.Address) (*bi
 // If no balance is cached yet, SubBalance will conduct a call to the ethereum
 // node to get the state of the balance before modifying it.
 // The modified value is then persisted in the internal state cache.
-func (c *ChainBatchCache) SubBalance(ctx context.Context, a common.Address, diff *big.Int) error {
-	old, err := c.GetBalance(ctx, a)
+func (c *Cached) SubBalance(ctx context.Context, a common.Address, diff *big.Int) error {
+	c.balancesLocks.Lock(a)
+	defer c.balancesLocks.Unlock(a)
+	return c.subBalance(ctx, a, diff)
+}
+
+func (c *Cached) subBalance(ctx context.Context, a common.Address, diff *big.Int) error {
+	old, err := c.getBalance(ctx, a)
 	if err != nil {
 		return err
 	}
@@ -89,8 +168,14 @@ func (c *ChainBatchCache) SubBalance(ctx context.Context, a common.Address, diff
 // If no balance is cached yet, AddBalance will conduct a call to the ethereum
 // node to get the state of the balance before modifying it.
 // The modified value is then persisted in the internal state cache.
-func (c *ChainBatchCache) AddBalance(ctx context.Context, a common.Address, diff *big.Int) error {
-	old, err := c.GetBalance(ctx, a)
+func (c *Cached) AddBalance(ctx context.Context, a common.Address, diff *big.Int) error {
+	c.balancesLocks.Lock(a)
+	defer c.balancesLocks.Unlock(a)
+	return c.addBalance(ctx, a, diff)
+}
+
+func (c *Cached) addBalance(ctx context.Context, a common.Address, diff *big.Int) error {
+	old, err := c.getBalance(ctx, a)
 	if err != nil {
 		return err
 	}
@@ -100,8 +185,13 @@ func (c *ChainBatchCache) AddBalance(ctx context.Context, a common.Address, diff
 
 // GetNonce polls and caches the state of account `a` balance at the
 // block number ChainBatchCache.AtBlockNumber.
-func (c *ChainBatchCache) GetNonce(ctx context.Context, a common.Address) (uint64, error) {
-	var err error
+func (c *Cached) GetNonce(ctx context.Context, a common.Address) (uint64, error) {
+	c.noncesLocks.Lock(a)
+	defer c.noncesLocks.Unlock(a)
+	var (
+		err   error
+		nonce uint64
+	)
 	nonce, exists := c.nonces[a]
 	if !exists {
 		nonce, err = c.Client.NonceAt(ctx, a, c.AtBlockNumber)
@@ -116,13 +206,19 @@ func (c *ChainBatchCache) GetNonce(ctx context.Context, a common.Address) (uint6
 // SetNonce sets the value in the nonce cache of account `a` to value `nonce`.
 // Once this is set, a call to GetNonce() will not poll the node but simply
 // return the set value.
-func (c *ChainBatchCache) SetNonce(a common.Address, nonce uint64) {
+func (c *Cached) SetNonce(a common.Address, nonce uint64) {
+	c.noncesLocks.Lock(a)
+	defer c.noncesLocks.Unlock(a)
 	c.nonces[a] = nonce
 }
 
-func (c *ChainBatchCache) Purge(a common.Address) {
+func (c *Cached) Purge(a common.Address) {
+	c.noncesLocks.Lock(a)
+	defer c.noncesLocks.Unlock(a)
+	c.balancesLocks.Lock(a)
+	defer c.balancesLocks.Unlock(a)
 	delete(c.nonces, a)
 	delete(c.balances, a)
 }
 
-var _ State = (*ChainBatchCache)(nil)
+var _ State = (*Cached)(nil)

--- a/rolling-shutter/collator/batchhandler/sequencer/statecache_test.go
+++ b/rolling-shutter/collator/batchhandler/sequencer/statecache_test.go
@@ -1,4 +1,4 @@
-package batch
+package sequencer
 
 import (
 	"context"

--- a/rolling-shutter/collator/batchhandler/sequencer/statecache_test.go
+++ b/rolling-shutter/collator/batchhandler/sequencer/statecache_test.go
@@ -26,12 +26,7 @@ func TestCaching(t *testing.T) {
 	eth.SetNonce(addr, nonce1, "latest")
 
 	ctx := context.Background()
-	cbc := &ChainBatchCache{
-		balances:      make(map[common.Address]*big.Int, 0),
-		nonces:        make(map[common.Address]uint64, 0),
-		Client:        client,
-		AtBlockNumber: nil, // nil means latest block
-	}
+	cbc := NewCached(client, nil)
 
 	// initial state should be polled from the client
 	bal, err := cbc.GetBalance(ctx, addr)

--- a/rolling-shutter/collator/batchhandler/transaction/pending.go
+++ b/rolling-shutter/collator/batchhandler/transaction/pending.go
@@ -1,0 +1,45 @@
+package transaction
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	txtypes "github.com/shutter-network/txtypes/types"
+)
+
+// Pending is a wrapper struct that associates additional
+// data to an incoming shutter transaction from a user.
+// It is used to keep track of sender, gas-fees and receive-time of
+// a shutter transaction.
+type Pending struct {
+	Tx          *txtypes.Transaction
+	TxBytes     []byte
+	Sender      common.Address
+	MinerFee    *big.Int
+	GasCost     *big.Int
+	ReceiveTime time.Time
+}
+
+func NewPending(signer txtypes.Signer, txBytes []byte, receiveTime time.Time) (*Pending, error) {
+	var tx txtypes.Transaction
+	err := tx.UnmarshalBinary(txBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	sender, err := signer.Sender(&tx)
+	if err != nil {
+		return nil, err
+	}
+
+	pendingTx := &Pending{
+		Tx:          &tx,
+		TxBytes:     txBytes,
+		Sender:      sender,
+		MinerFee:    &big.Int{},
+		GasCost:     &big.Int{},
+		ReceiveTime: receiveTime,
+	}
+	return pendingTx, nil
+}

--- a/rolling-shutter/collator/batchhandler/transaction/queue.go
+++ b/rolling-shutter/collator/batchhandler/transaction/queue.go
@@ -1,4 +1,4 @@
-package batch
+package transaction
 
 import (
 	"github.com/ethereum/go-ethereum/common"
@@ -9,23 +9,23 @@ import (
 
 func NewTransactionQueue() *TransactionQueue {
 	return &TransactionQueue{
-		txqueue: make([]*PendingTransaction, 0),
+		txqueue: make([]*Pending, 0),
 		Senders: make(map[common.Address]bool, 0),
 	}
 }
 
 // TransactionQueue is a container struct allowing
-// for append-only operation on a list of `PendingTransaction`.
+// for append-only operation on a list of `Pending`.
 // TransactionQueue implements convenience methods to
 // join two queues, generate the hash of all queued transactions
 // and show the set of all transactions sender addresses.
 type TransactionQueue struct {
-	txqueue []*PendingTransaction
+	txqueue []*Pending
 	Senders map[common.Address]bool
 }
 
 func (q *TransactionQueue) JoinRight(other *TransactionQueue) *TransactionQueue {
-	txqueue := make([]*PendingTransaction, q.Len()+other.Len())
+	txqueue := make([]*Pending, q.Len()+other.Len())
 	n := copy(txqueue, q.txqueue)
 	copy(txqueue[n:], other.txqueue)
 
@@ -50,7 +50,7 @@ func (q *TransactionQueue) Hash() []byte {
 func (q *TransactionQueue) Transactions() []*txtypes.Transaction {
 	txs := make([]*txtypes.Transaction, len(q.txqueue))
 	for i, p := range q.txqueue {
-		txs[i] = p.tx
+		txs[i] = p.Tx
 	}
 	return txs
 }
@@ -58,20 +58,20 @@ func (q *TransactionQueue) Transactions() []*txtypes.Transaction {
 func (q *TransactionQueue) Bytes() [][]byte {
 	l := make([][]byte, q.Len())
 	for i, tx := range q.txqueue {
-		l[i] = tx.txBytes
+		l[i] = tx.TxBytes
 	}
 	return l
 }
 
 func (q *TransactionQueue) Len() int { return len(q.txqueue) }
 
-func (q *TransactionQueue) Enqueue(tx *PendingTransaction) {
-	q.Senders[tx.sender] = true
+func (q *TransactionQueue) Enqueue(tx *Pending) {
+	q.Senders[tx.Sender] = true
 	q.txqueue = append(q.txqueue, tx)
 }
 
 // TotalByteSize returns the sum of the size of all transactions measured in bytes.
-func (q *TransactionQueue) TotalByteSize() int {
+func (q *Queue) TotalByteSize() int {
 	bs := q.Bytes()
 	s := 0
 	for _, b := range bs {

--- a/rolling-shutter/collator/batchhandler/transaction/queue.go
+++ b/rolling-shutter/collator/batchhandler/transaction/queue.go
@@ -1,61 +1,81 @@
 package transaction
 
 import (
+	"sync"
+
 	"github.com/ethereum/go-ethereum/common"
-	txtypes "github.com/shutter-network/txtypes/types"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/shmsg"
 )
 
-func NewTransactionQueue() *TransactionQueue {
-	return &TransactionQueue{
+func NewQueue() *Queue {
+	return &Queue{
 		txqueue: make([]*Pending, 0),
-		Senders: make(map[common.Address]bool, 0),
+		senders: make(map[common.Address]bool, 0),
 	}
 }
 
-// TransactionQueue is a container struct allowing
+// `Queue` is a container struct allowing
 // for append-only operation on a list of `Pending`.
-// TransactionQueue implements convenience methods to
+// `Queue` implements convenience methods to
 // join two queues, generate the hash of all queued transactions
 // and show the set of all transactions sender addresses.
-type TransactionQueue struct {
+type Queue struct {
+	mu      sync.RWMutex
 	txqueue []*Pending
-	Senders map[common.Address]bool
+	senders map[common.Address]bool
 }
 
-func (q *TransactionQueue) JoinRight(other *TransactionQueue) *TransactionQueue {
-	txqueue := make([]*Pending, q.Len()+other.Len())
+func (q *Queue) JoinRight(other *Queue) *Queue {
+	q.mu.RLock()
+	other.mu.RLock()
+	defer other.mu.RUnlock()
+	defer q.mu.RUnlock()
+
+	txqueue := make([]*Pending, len(q.txqueue)+len(other.txqueue))
 	n := copy(txqueue, q.txqueue)
 	copy(txqueue[n:], other.txqueue)
 
-	senders := make(map[common.Address]bool, len(q.Senders))
-	for addr, v := range q.Senders {
+	senders := make(map[common.Address]bool, len(q.senders))
+	for addr, v := range q.senders {
 		senders[addr] = v
 	}
-	for addr, v := range other.Senders {
+	for addr, v := range other.senders {
 		senders[addr] = v
 	}
-	return &TransactionQueue{txqueue: txqueue, Senders: senders}
+	return &Queue{txqueue: txqueue, senders: senders}
 }
 
-func (q *TransactionQueue) Hash() []byte {
+func (q *Queue) Hash() []byte {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	txHashes := make([][]byte, q.Len())
-	for i, t := range q.Transactions() {
-		txHashes[i] = t.Hash().Bytes()
+	for i, t := range q.txqueue {
+		txHashes[i] = t.Tx.Hash().Bytes()
 	}
 	return shmsg.HashTransactions(txHashes)
 }
 
-func (q *TransactionQueue) Transactions() []*txtypes.Transaction {
-	txs := make([]*txtypes.Transaction, len(q.txqueue))
-	for i, p := range q.txqueue {
-		txs[i] = p.Tx
-	}
-	return txs
+func (q *Queue) Transactions() []*Pending {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	txqueue := make([]*Pending, len(q.txqueue))
+	copy(txqueue, q.txqueue)
+	return txqueue
 }
 
-func (q *TransactionQueue) Bytes() [][]byte {
+func (q *Queue) Pop() []*Pending {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	txqueue := q.txqueue
+	q.txqueue = make([]*Pending, 0)
+	q.senders = make(map[common.Address]bool)
+	return txqueue
+}
+
+func (q *Queue) Bytes() [][]byte {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	l := make([][]byte, q.Len())
 	for i, tx := range q.txqueue {
 		l[i] = tx.TxBytes
@@ -63,10 +83,14 @@ func (q *TransactionQueue) Bytes() [][]byte {
 	return l
 }
 
-func (q *TransactionQueue) Len() int { return len(q.txqueue) }
+func (q *Queue) Len() int {
+	return len(q.txqueue)
+}
 
-func (q *TransactionQueue) Enqueue(tx *Pending) {
-	q.Senders[tx.Sender] = true
+func (q *Queue) Enqueue(tx *Pending) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.senders[tx.Sender] = true
 	q.txqueue = append(q.txqueue, tx)
 }
 

--- a/rolling-shutter/collator/batchhandler/transaction/queue_test.go
+++ b/rolling-shutter/collator/batchhandler/transaction/queue_test.go
@@ -1,4 +1,4 @@
-package batch
+package transaction
 
 import (
 	"bytes"
@@ -18,7 +18,7 @@ func TestTotalByteSize(t *testing.T) {
 	chainID := big.NewInt(1)
 	signer := txtypes.LatestSignerForChainID(chainID)
 
-	q := NewTransactionQueue()
+	q := NewQueue()
 	assert.Equal(t, q.TotalByteSize(), 0)
 
 	for _, payloadSize := range []int{0, 10, 100, 1000} {
@@ -35,7 +35,7 @@ func TestTotalByteSize(t *testing.T) {
 		assert.NilError(t, err)
 		txBytes, err := tx.MarshalBinary()
 		assert.NilError(t, err)
-		pendingTx, err := NewPendingTransaction(signer, txBytes, time.Now())
+		pendingTx, err := NewPending(signer, txBytes, time.Now())
 		assert.NilError(t, err)
 
 		sizeBefore := q.TotalByteSize()

--- a/rolling-shutter/collator/collator.go
+++ b/rolling-shutter/collator/collator.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/chainobserver"
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/batch"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/batchhandler"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/cltrdb"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/cltrtopics"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/config"
@@ -40,7 +40,7 @@ type collator struct {
 
 	l1Client     *ethclient.Client
 	contracts    *deployment.Contracts
-	batchHandler *batch.BatchHandler
+	batchHandler *batchhandler.BatchHandler
 
 	p2p    *p2p.P2PHandler
 	dbpool *pgxpool.Pool
@@ -82,7 +82,7 @@ func Run(ctx context.Context, cfg config.Config) error {
 		return err
 	}
 
-	batchHandler, err := batch.NewBatchHandler(cfg, dbpool)
+	batchHandler, err := batchhandler.NewBatchHandler(cfg, dbpool)
 	if err != nil {
 		return err
 	}

--- a/rolling-shutter/collator/http.go
+++ b/rolling-shutter/collator/http.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	"golang.org/x/crypto/sha3"
 
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/batch"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/batchhandler"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/cltrdb"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/oapi"
 )
@@ -35,7 +35,7 @@ func (srv *server) Ping(w http.ResponseWriter, _ *http.Request) {
 
 func (srv *server) GetNextEpoch(w http.ResponseWriter, req *http.Request) {
 	db := cltrdb.New(srv.c.dbpool)
-	epoch, _, err := batch.GetNextBatch(req.Context(), db)
+	epoch, _, err := batchhandler.GetNextBatch(req.Context(), db)
 	if err != nil {
 		sendError(w, http.StatusInternalServerError, err.Error())
 	}


### PR DESCRIPTION
*This PR is part of a bigger feature implementation ( #286 )
Please go through through the review commit by commit and keep in mind that a series of PRs
will follow so that ultimately the `feature/collator-batch-handler` branch can be merged to `main` to fix #286.*

This PR includes:
- refactoring of the `batch` into sub-packages
- threadsafety fixes for several classes
- add an JSON-RPC endpoint to the mock eth-server implementation
