### PR TITLE
Mock-sequencer improvements

### DIFF
--- a/rolling-shutter/go.mod
+++ b/rolling-shutter/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgx/v4 v4.14.1
+	github.com/justinas/alice v1.2.0
 	github.com/kr/pretty v0.3.0
 	github.com/kyleconroy/sqlc v1.12.0
 	github.com/libp2p/go-libp2p v0.14.4
@@ -186,6 +187,7 @@ require (
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/rs/cors v1.8.2 // indirect
+	github.com/rs/xid v1.3.0 // indirect
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect

--- a/rolling-shutter/go.mod
+++ b/rolling-shutter/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/rs/zerolog v1.26.1
 	github.com/shutter-network/shutter/shlib v0.1.10
-	github.com/shutter-network/txtypes v0.0.4
+	github.com/shutter-network/txtypes v0.0.5
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.11.0

--- a/rolling-shutter/go.sum
+++ b/rolling-shutter/go.sum
@@ -931,6 +931,8 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
+github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
@@ -1646,6 +1648,7 @@ github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/xid v1.3.0 h1:6NjYksEUlhurdVehpc7S7dk6DAmcKv8V9gG0FsVN2U4=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=

--- a/rolling-shutter/go.sum
+++ b/rolling-shutter/go.sum
@@ -1709,8 +1709,8 @@ github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYED
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/shutter-network/shutter/shlib v0.1.10 h1:p0O35mZBHqDD/UXTMYh6GtKtPCG7kv0b7DWpMNYOXrE=
 github.com/shutter-network/shutter/shlib v0.1.10/go.mod h1:V003agcyGtHXQT0yIe3xmvN6AYfqSpnJPnHCwmiLzF8=
-github.com/shutter-network/txtypes v0.0.4 h1:44vSCcmePg62f9b3eePtXEuqv0cH3nMyC5bc0o/5Gm8=
-github.com/shutter-network/txtypes v0.0.4/go.mod h1:OojGWxGTcroGInvhbux+FgRw82pHehftrQYZIgeywos=
+github.com/shutter-network/txtypes v0.0.5 h1:14X4abkvrm27Jb4av0WQNeIcwHr5IP72gUa0ZK6yvYw=
+github.com/shutter-network/txtypes v0.0.5/go.mod h1:OojGWxGTcroGInvhbux+FgRw82pHehftrQYZIgeywos=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/rolling-shutter/mocksequencer/admin.go
+++ b/rolling-shutter/mocksequencer/admin.go
@@ -21,16 +21,16 @@ func (s *AdminService) AddCollator(address string, l1BlockNumber uint64) (int, e
 	if err != nil {
 		return 0, err
 	}
-	s.processor.collators[l1BlockNumber] = collator
+	s.processor.collators.Set(collator, l1BlockNumber)
 	return 1, nil
 }
 
 func (s *AdminService) AddEonKey(eonKey string, l1BlockNumber uint64) (int, error) {
-	bytes, err := hexutil.Decode(eonKey)
+	eonKeyBytes, err := hexutil.Decode(eonKey)
 	if err != nil {
 		// TODO return specific decode error
 		return 0, err
 	}
-	s.processor.eonKeys[l1BlockNumber] = bytes
+	s.processor.eonKeys.Set(eonKeyBytes, l1BlockNumber)
 	return 1, nil
 }

--- a/rolling-shutter/mocksequencer/admin.go
+++ b/rolling-shutter/mocksequencer/admin.go
@@ -1,6 +1,9 @@
 package mocksequencer
 
-import "github.com/ethereum/go-ethereum/common/hexutil"
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
+)
 
 type AdminService struct {
 	processor *SequencerProcessor
@@ -28,7 +31,7 @@ func (s *AdminService) AddCollator(address string, l1BlockNumber uint64) (int, e
 func (s *AdminService) AddEonKey(eonKey string, l1BlockNumber uint64) (int, error) {
 	eonKeyBytes, err := hexutil.Decode(eonKey)
 	if err != nil {
-		// TODO return specific decode error
+		err = errors.Wrap(err, "eon key could not be decoded")
 		return 0, err
 	}
 	s.processor.eonKeys.Set(eonKeyBytes, l1BlockNumber)

--- a/rolling-shutter/mocksequencer/eth.go
+++ b/rolling-shutter/mocksequencer/eth.go
@@ -46,7 +46,6 @@ func (s *EthService) ChainID() (string, error) {
 func (s *EthService) GetBlockByNumber(blockNumber string, _ bool) (json.RawMessage, error) {
 	b, exists := s.processor.blocks[blockNumber]
 	if !exists {
-		// TODO check spec for correct return value
 		return json.RawMessage("\"null\""), nil
 	}
 	return jsonBlock(b.baseFee, b.gasLimit), nil

--- a/rolling-shutter/mocksequencer/processor.go
+++ b/rolling-shutter/mocksequencer/processor.go
@@ -1,6 +1,7 @@
 package mocksequencer
 
 import (
+	"context"
 	"math/big"
 	"sort"
 	"sync"
@@ -10,6 +11,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	txtypes "github.com/shutter-network/txtypes/types"
+)
+
+const (
+	BaseFee  = 22000
+	GasLimit = 2200000000
 )
 
 type blockData struct {
@@ -95,8 +101,8 @@ func New(chainID *big.Int, port int16) *SequencerProcessor {
 		signer:     txtypes.NewLondonSigner(chainID),
 		batchIndex: 0,
 	}
-	// TODO Expose as parameters
-	sequencer.setBlock(big.NewInt(22000), 2200000, "latest")
+	baseFee := big.NewInt(BaseFee)
+	sequencer.setBlock(baseFee, GasLimit, "latest")
 	return sequencer
 }
 

--- a/rolling-shutter/mocksequencer/processor_test.go
+++ b/rolling-shutter/mocksequencer/processor_test.go
@@ -1,0 +1,42 @@
+package mocksequencer
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func assertFind[T any](t *testing.T, mp *activationBlockMap[T], block int, expectedValue T) {
+	t.Helper()
+	found, err := mp.Find(uint64(block))
+	assert.NilError(t, err)
+	assert.Equal(t, found, expectedValue)
+}
+
+func assertError[T any](t *testing.T, mp *activationBlockMap[T], block int, errMessage string) {
+	t.Helper()
+	_, err := mp.Find(uint64(block))
+	assert.Error(t, err, errMessage)
+}
+
+func TestActivationBlockMap(t *testing.T) {
+	mp := newActivationBlockMap[string]()
+	mp.Set("third", 5)
+	mp.Set("first", 0)
+	mp.Set("second", 1)
+
+	assertFind(t, mp, 0, "first")
+	assertFind(t, mp, 1, "second")
+	assertFind(t, mp, 4, "second")
+	assertFind(t, mp, 5, "third")
+	assertFind(t, mp, 6, "third")
+	assertFind(t, mp, 999999, "third")
+}
+
+func TestActivationBlockMapErrors(t *testing.T) {
+	mp := newActivationBlockMap[uint64]()
+	assertError(t, mp, 0, "no value was set")
+
+	mp.Set(42, 10)
+	assertError(t, mp, 9, "no value was found")
+}

--- a/rolling-shutter/mocksequencer/shutter.go
+++ b/rolling-shutter/mocksequencer/shutter.go
@@ -1,7 +1,10 @@
 package mocksequencer
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	txtypes "github.com/shutter-network/txtypes/types"
@@ -25,35 +28,85 @@ func (s *ShutterService) GetBatchIndex() (string, error) {
 	return hexutil.EncodeUint64(s.processor.batchIndex), nil
 }
 
-func (s *ShutterService) SubmitBatch(transaction string) (string, error) {
-	txBytes, err := hexutil.Decode(transaction)
+func (s *ShutterService) validateBatch(tx *txtypes.Transaction) error {
+	if tx.Type() != txtypes.BatchTxType {
+		return errors.New("unexpected transaction type")
+	}
+
+	if tx.ChainId().Cmp(s.processor.chainID) != 0 {
+		return errors.New("chain-id mismatch")
+	}
+
+	if s.processor.batchIndex != tx.BatchIndex()-1 {
+		return errors.New("incorrect batch-index for next batch")
+	}
+
+	collator, err := s.processor.collators.Find(tx.L1BlockNumber())
+	if err != nil {
+		return errors.Wrap(err, "collator validation failed")
+	}
+	sender, err := s.processor.signer.Sender(tx)
+	if err != nil {
+		return errors.Wrap(err, "error recovering batch tx sender")
+	}
+	if collator != sender {
+		return errors.Wrap(err, "not signed by correct collator")
+	}
+
+	// all checks passed, the batch-tx is valid (disregarding validity of included encrypted transactions)
+	return nil
+}
+
+func (s *ShutterService) SubmitBatch(ctx context.Context, batchTransaction string) (string, error) {
+	var (
+		tx      txtypes.Transaction
+		gasPool core.GasPool
+	)
+
+	txBytes, err := hexutil.Decode(batchTransaction)
 	if err != nil {
 		return "", errors.Wrap(err, "can't decode incoming tx bytes")
 	}
 
-	var tx txtypes.Transaction
 	err = tx.UnmarshalBinary(txBytes)
 	if err != nil {
 		return "", errors.Wrap(err, "can't unmarshal incoming bytes to transaction")
 	}
-	// TODO process the BatchTx
-	// - validate the batchtx
-	// - pretty log the batch tx
-	// - decrypt and pretty log all transactions
 
-	log.Info().Msg("received batch-tx")
-	if s.processor.batchIndex != tx.BatchIndex()-1 {
-		return "", errors.New("incorrect batch-index for next batch")
+	err = s.validateBatch(&tx)
+	txStr, _ := tx.MarshalJSON()
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).RawJSON("transaction", txStr).Msg("received invalid batch transaction")
+		return "", errors.Wrap(err, "batch-tx invalid")
 	}
+
+	// for now, just set the current view on the L1 chain to the
+	// claimed collator's view
+	currentL1BlockNumber := tx.L1BlockNumber()
+	eonKey, err := s.processor.eonKeys.Find(currentL1BlockNumber)
+	if err != nil {
+		err = errors.Wrap(err, "no eon key found for batch transaction")
+		log.Ctx(ctx).Error().Err(err).Msg("error while retrieving eon key")
+		return "", err
+	}
+
+	gasPool.AddGas(GasLimit)
 	for _, shutterTx := range tx.Transactions() {
-		err := s.processor.processEncryptedTx(shutterTx)
+		err := s.processor.processEncryptedTx(ctx, &gasPool, tx.BatchIndex(), tx.L1BlockNumber(), shutterTx, tx.DecryptionKey(), eonKey)
 		if err != nil {
-			log.Error().Err(err).Msg("tx not processable, dropping transaction")
-		} else {
-			log.Info().Msg("successfully applied shutter-tx")
+			// those are conditions that the collator can check,
+			// so an error here means the whole batch is invalid
+			err := errors.Wrap(err, "transaction invalid")
+			return "", err
 		}
+		log.Info().Msg("successfully applied shutter-tx")
 	}
+
+	sender, _ := s.processor.signer.Sender(&tx)
+	log.Ctx(ctx).Info().Str("signer", sender.Hex()).RawJSON("transaction", txStr).Msg("received batch transaction")
 	s.processor.batchIndex = tx.BatchIndex()
-	log.Info().Str("batch", hexutil.EncodeUint64(s.processor.batchIndex)).Msg("started new batch")
+
+	log.Ctx(ctx).Info().Str("batch", hexutil.EncodeUint64(s.processor.batchIndex)).Msg("started new batch")
+
 	return tx.Hash().Hex(), nil
 }


### PR DESCRIPTION
### Changes
This PR improves the logging and transaction validation logic of the mock-sequencer.
- activation block based collator retrieval
- activation block based eon key retrieval (although encryption is not yet implemented)
- l1blocknumber matching between shutter-tx's and the parent batch-tx
- pretty logging of shutter-tx and batch-tx
- further batch-tx verification improvements
- bump `txtypes` version to `v0.0.5`

~~#### Missing:
Once https://github.com/shutter-network/go-ethereum/pull/6 is merged and the changes are reflected in the`txtypes` repository,
the imported `txtypes` version  in rolling-shutter has to be updated in this PR.
Otherwise the JSON-marshaling of the transaction logging will not produce the correct transaction structs.~~