### PR TITLE
Collator: batch-closing routine

### DIFF
--- a/rolling-shutter/collator/batcher/batcher_test.go
+++ b/rolling-shutter/collator/batcher/batcher_test.go
@@ -38,17 +38,17 @@ func TestRejectBadTransactionsIntegration(t *testing.T) {
 	t.Run("Future", func(t *testing.T) {
 		tx, _ := fixtures.MakeTx(t, 0, nextBatchIndex+batchIndexAcceptenceInterval, 0, 22000)
 		err := fixtures.Batcher.EnqueueTx(ctx, tx)
-		assert.Error(t, err, errBatchIndexTooFarInFuture.Error())
+		assert.Error(t, err, ErrBatchIndexTooFarInFuture.Error())
 	})
 	t.Run("Past", func(t *testing.T) {
 		tx, _ := fixtures.MakeTx(t, 0, nextBatchIndex-1, 0, 22000)
 		err := fixtures.Batcher.EnqueueTx(ctx, tx)
-		assert.Error(t, err, errBatchIndexInPast.Error())
+		assert.Error(t, err, ErrBatchIndexInPast.Error())
 	})
 	t.Run("Nonce", func(t *testing.T) {
 		tx, _ := fixtures.MakeTx(t, 0, nextBatchIndex, 1, 22000)
 		err := fixtures.Batcher.EnqueueTx(ctx, tx)
-		assert.Error(t, err, errNonceMismatch.Error())
+		assert.Error(t, err, ErrNonceMismatch.Error())
 	})
 	t.Run("Gas", func(t *testing.T) {
 		tx, _ := fixtures.MakeTx(t, 0, nextBatchIndex, 0, 2)
@@ -62,7 +62,7 @@ func TestRejectBadTransactionsIntegration(t *testing.T) {
 		defer func() { fixtures.ChainID = chainID }()
 		tx, _ := fixtures.MakeTx(t, 0, nextBatchIndex+1, 0, 22000)
 		err := fixtures.Batcher.EnqueueTx(ctx, tx)
-		assert.Error(t, err, errWrongChainID.Error())
+		assert.Error(t, err, ErrWrongChainID.Error())
 	})
 }
 
@@ -76,7 +76,7 @@ func TestRejectTxNotEnoughFundsIntegration(t *testing.T) {
 	nextBatchIndex := int(fixtures.Params.InitialEpochID.Uint64())
 	tx, _ := fixtures.MakeTx(t, 1, nextBatchIndex, 0, 22000)
 	err := fixtures.Batcher.EnqueueTx(ctx, tx)
-	assert.Error(t, err, errCannotPayGasFee.Error())
+	assert.Error(t, err, ErrCannotPayGasFee.Error())
 }
 
 func TestConfirmTransactionsIntegration(t *testing.T) {
@@ -125,13 +125,13 @@ func TestCloseBatchIntegration(t *testing.T) {
 
 	t.Run("initChainStateWaitForSequencer", func(t *testing.T) {
 		err = fixtures.Batcher.initChainState(ctx)
-		assert.Error(t, err, errWaitForSequencer.Error())
+		assert.Error(t, err, ErrWaitForSequencer.Error())
 	})
 
 	t.Run("batchAlreadyExists", func(t *testing.T) {
 		fixtures.EthL2Server.SetBatchIndex(fixtures.Params.InitialEpochID.Uint64() + 1)
 		err = fixtures.Batcher.initChainState(ctx)
-		assert.Error(t, err, errBatchAlreadyExists.Error())
+		assert.Error(t, err, ErrBatchAlreadyExists.Error())
 	})
 
 	t.Run("initChainStateSetsNextBatchChainState", func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestOpenNextBatch(t *testing.T) {
 
 	tx3, _ := fixtures.MakeTx(t, 2, int(nextBatchIndex), 0, 22000)
 	err = fixtures.Batcher.EnqueueTx(ctx, tx3)
-	assert.Error(t, err, errCannotPayGasFee.Error())
+	assert.Error(t, err, ErrCannotPayGasFee.Error())
 
 	assert.Check(t, fixtures.Batcher.nextBatchChainState != nil, "nextBatchChainState field not initialized")
 

--- a/rolling-shutter/collator/batcher/chainstate.go
+++ b/rolling-shutter/collator/batcher/chainstate.go
@@ -12,11 +12,11 @@ import (
 )
 
 var (
-	errNonceMismatch         = errors.New("nonce mismatch")
-	errAccountNotInitialized = errors.New("account not initialized")
-	errCannotPayGasFee       = errors.New("not enough funds to pay gas fee")
-	errGasLimitReached       = errors.New("gas limit reached")
-	errBatchSizeLimitReached = errors.New("batch size limit reached")
+	ErrNonceMismatch         = errors.New("nonce mismatch")
+	ErrAccountNotInitialized = errors.New("account not initialized")
+	ErrCannotPayGasFee       = errors.New("not enough funds to pay gas fee")
+	ErrGasLimitReached       = errors.New("gas limit reached")
+	ErrBatchSizeLimitReached = errors.New("batch size limit reached")
 )
 
 // ChainState is used by the collator to simulate applying transactions to a per block state and
@@ -67,11 +67,11 @@ func (chst *ChainState) CanApplyTx(tx *txtypes.Transaction, txSizeInBytes uint64
 		return err
 	}
 	if !chst.IsAccountInitialized(account) {
-		return errAccountNotInitialized
+		return ErrAccountNotInitialized
 	}
 
 	if tx.Nonce() != chst.nonces[account] {
-		return errNonceMismatch
+		return ErrNonceMismatch
 	}
 
 	err = batch.ValidateGasParams(tx, chst.baseFee)
@@ -81,15 +81,15 @@ func (chst *ChainState) CanApplyTx(tx *txtypes.Transaction, txSizeInBytes uint64
 
 	gasCost := batch.CalculateGasCost(tx, chst.baseFee)
 	if chst.balances[account].Cmp(gasCost) < 0 {
-		return errCannotPayGasFee
+		return ErrCannotPayGasFee
 	}
 
 	if chst.gasUsed+tx.Gas() > chst.blockGasLimit {
-		return errGasLimitReached
+		return ErrGasLimitReached
 	}
 
 	if chst.sizeInBytes+txSizeInBytes > batch.BatchSizeLimit {
-		return errBatchSizeLimitReached
+		return ErrBatchSizeLimitReached
 	}
 
 	return nil

--- a/rolling-shutter/collator/eonhandling_test.go
+++ b/rolling-shutter/collator/eonhandling_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"testing"
+	"time"
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"gotest.tools/assert"
@@ -30,6 +31,7 @@ func newTestConfig(t *testing.T) config.Config {
 		EthereumKey:         ethereumKey,
 		ExecutionBlockDelay: uint32(5),
 		InstanceID:          123,
+		EpochDuration:       1 * time.Second,
 	}
 }
 

--- a/rolling-shutter/collator/epochhandling.go
+++ b/rolling-shutter/collator/epochhandling.go
@@ -18,8 +18,6 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/shmsg"
 )
 
-const dBPollTime = 500 * time.Millisecond
-
 func (c *collator) handleDecryptionKey(ctx context.Context, msg *shmsg.DecryptionKey) ([]shmsg.P2PMessage, error) {
 	epochID, err := epochid.BytesToEpochID(msg.EpochID)
 	if err != nil {

--- a/rolling-shutter/go.mod
+++ b/rolling-shutter/go.mod
@@ -3,6 +3,7 @@ module github.com/shutter-network/rolling-shutter/rolling-shutter
 go 1.18
 
 require (
+	github.com/benbjohnson/clock v1.3.0
 	github.com/deepmap/oapi-codegen v1.9.1
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/getkin/kin-openapi v0.87.0
@@ -40,7 +41,6 @@ require (
 require (
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220626175859-9abda183db8e // indirect
-	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd v0.22.3 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.2 // indirect

--- a/rolling-shutter/medley/retry/options.go
+++ b/rolling-shutter/medley/retry/options.go
@@ -8,9 +8,17 @@ import (
 	"github.com/google/uuid"
 )
 
+// NumberOfRetries specifies the
+// number of retries are conducted
+// until the call finally returns.
+// `-1` is a special value that results in
+// infinite retries.
 func NumberOfRetries(n int) Option {
 	return func(r *retrier) {
 		r.numRetries = n
+		if n == -1 {
+			r.infiniteRetries = true
+		}
 	}
 }
 
@@ -23,6 +31,12 @@ func MaxInterval(t time.Duration) Option {
 func Interval(t time.Duration) Option {
 	return func(r *retrier) {
 		r.interval = t
+	}
+}
+
+func StopOnErrors(e ...error) Option {
+	return func(r *retrier) {
+		r.cancelingErrors = e
 	}
 }
 

--- a/rolling-shutter/medley/retry/options.go
+++ b/rolling-shutter/medley/retry/options.go
@@ -14,9 +14,9 @@ func NumberOfRetries(n int) Option {
 	}
 }
 
-func MaxInterval(n int) Option {
+func MaxInterval(t time.Duration) Option {
 	return func(r *retrier) {
-		r.numRetries = n
+		r.maxInterval = t
 	}
 }
 

--- a/rolling-shutter/medley/retry/options.go
+++ b/rolling-shutter/medley/retry/options.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/google/uuid"
 )
 
@@ -63,5 +64,14 @@ func LogIdentifier(s string) Option {
 	id := uuid.NewString()
 	return func(r *retrier) {
 		r.identifier = id + ":" + s
+	}
+}
+
+// UseClock injects a different `clock.Clock`
+// implementation than the default `time`
+// wrapper. Mainly used for mocking.
+func UseClock(c clock.Clock) Option {
+	return func(r *retrier) {
+		r.clock = c
 	}
 }

--- a/rolling-shutter/medley/retry/retry.go
+++ b/rolling-shutter/medley/retry/retry.go
@@ -9,7 +9,7 @@ import (
 )
 
 func multDuration(a time.Duration, m float64) time.Duration {
-	return time.Duration(float64(a) * m)
+	return time.Duration(float64(a.Nanoseconds()) * m)
 }
 
 type retrier struct {
@@ -23,13 +23,13 @@ type retrier struct {
 	identifier       string
 }
 
-func defaultOptions() Option {
-	return func(r *retrier) {
-		r.numRetries = 3
-		r.interval = 2 * time.Second
-		r.maxInterval = 60 * time.Second
-		r.multiplier = 1.
-		r.cancelingErrors = []error{}
+func newRetrier() *retrier {
+	return &retrier{
+		numRetries:      3,
+		interval:        2 * time.Second,
+		maxInterval:     60 * time.Second,
+		multiplier:      1.,
+		cancelingErrors: []error{},
 	}
 }
 
@@ -89,8 +89,7 @@ type (
 // FunctionCall calls the given function multiple times until it doesn't return an error
 // or one of any optional, user-defined specific errors is returned.
 func FunctionCall[T any](ctx context.Context, fn RetriableFunction[T], opts ...Option) (T, error) {
-	retrier := &retrier{}
-	opts = append([]Option{defaultOptions()}, opts...)
+	retrier := newRetrier()
 	retrier.option(opts)
 
 	next := make(chan time.Time, 1)

--- a/rolling-shutter/medley/retry/retry.go
+++ b/rolling-shutter/medley/retry/retry.go
@@ -63,7 +63,7 @@ func (r *retrier) iterator(next <-chan time.Time) <-chan time.Time {
 	go func() {
 		defer close(iter)
 		interval := r.interval
-		// emit the time once, this is the initial event
+		// emit the time once, this is the initial action
 		// (e.g. the initial function call)
 		iter <- r.clock.Now()
 		i := 0

--- a/rolling-shutter/medley/retry/retry_test.go
+++ b/rolling-shutter/medley/retry/retry_test.go
@@ -1,0 +1,207 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"gotest.tools/assert"
+
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/comparer"
+)
+
+var (
+	errDefault          = errors.New("retry_test: default error")
+	errAtSecondCall     = errors.New("retry_test: error at 2nd call")
+	nullTime            time.Time
+	baseInterval        = 50 * time.Millisecond
+	functionRuntime     = 500 * time.Microsecond
+	defaultTestDeadline = 1 * time.Second
+)
+
+func TestMultDuration(t *testing.T) {
+	assert.Equal(t, multDuration(time.Millisecond, 0), 0*time.Millisecond)
+	assert.Equal(t, multDuration(time.Millisecond, 2), 2*time.Millisecond)
+	assert.Equal(t, multDuration(time.Millisecond, math.Pow(1.5, 3)), 3375*time.Microsecond)
+}
+
+type testFlags struct {
+	name          string
+	opts          []Option
+	expectedErr   error
+	expectedTimes []time.Duration
+	deadline      time.Duration
+}
+
+var testFlagTable = []testFlags{
+	{
+		"test 5 retries with constant retry time",
+		[]Option{
+			Interval(baseInterval),
+			NumberOfRetries(5),
+		},
+		errDefault,
+		[]time.Duration{
+			baseInterval + functionRuntime,
+			baseInterval + functionRuntime,
+			baseInterval + functionRuntime,
+			baseInterval + functionRuntime,
+			baseInterval + functionRuntime,
+		},
+		defaultTestDeadline,
+	},
+	{
+		"test 5 retries with exponential backoff time",
+		[]Option{
+			Interval(baseInterval),
+			NumberOfRetries(5),
+			ExponentialBackoff(),
+		},
+		errDefault,
+		[]time.Duration{
+			baseInterval + functionRuntime,
+			multDuration(baseInterval, 1.5) + functionRuntime,
+			multDuration(baseInterval, math.Pow(1.5, 2)) + functionRuntime,
+			multDuration(baseInterval, math.Pow(1.5, 3)) + functionRuntime,
+			multDuration(baseInterval, math.Pow(1.5, 4)) + functionRuntime,
+		},
+		defaultTestDeadline,
+	},
+	{
+		"test max interval on exponential backoff",
+		[]Option{
+			Interval(baseInterval),
+			NumberOfRetries(5),
+			MaxInterval(
+				multDuration(baseInterval, math.Pow(1.5, 2)),
+			),
+			ExponentialBackoff(),
+		},
+		errDefault,
+		[]time.Duration{
+			baseInterval + functionRuntime,
+			multDuration(baseInterval, 1.5) + functionRuntime,
+			multDuration(baseInterval, math.Pow(1.5, 2)) + functionRuntime,
+			// now the max interval kicks in,
+			// stopping the exponential backoff from here
+			multDuration(baseInterval, math.Pow(1.5, 2)) + functionRuntime,
+			multDuration(baseInterval, math.Pow(1.5, 2)) + functionRuntime,
+		},
+		defaultTestDeadline,
+	},
+	{
+		"test stop on specific error",
+		[]Option{
+			Interval(baseInterval),
+			NumberOfRetries(2),
+			StopOnErrors(errAtSecondCall),
+		},
+		// error should get passed through as well
+		errAtSecondCall,
+		// only 1 retry
+		[]time.Duration{
+			baseInterval + functionRuntime,
+		},
+		defaultTestDeadline,
+	},
+	{
+		"test run infinitely until ctx cancel",
+		[]Option{
+			Interval(baseInterval),
+			// -1 means infinite retries
+			NumberOfRetries(-1),
+		},
+		// we expect the DeadlineExceeded error here
+		// instead of the error raised by the function
+		context.DeadlineExceeded,
+		nil, // don't test the times here
+		10 * baseInterval,
+	},
+	{
+		"smoketest logging options",
+		// just test that the logging options
+		// don't cause runtime errors
+		[]Option{
+			Interval(baseInterval),
+			LogCaptureStackFrameContext(),
+			LogIdentifier("test_retry"),
+			NumberOfRetries(2),
+		},
+		errDefault,
+		nil, // don't test the times here
+		defaultTestDeadline,
+	},
+}
+
+func TestRetryFunctionCall(t *testing.T) {
+	for _, flags := range testFlagTable {
+		t.Run(flags.name, func(t *testing.T) {
+			testRetryFunctionCall(t, flags)
+		})
+	}
+}
+
+func testRetryFunctionCall(t *testing.T, flags testFlags) { //nolint:thelper
+	var lastCall time.Time
+	mockClock := clock.NewMock()
+	callCount := 0
+	calledRelativeTimes := make([]time.Duration, 0)
+	fn := func(ctx context.Context) (bool, error) {
+		called := mockClock.Now()
+		callCount++
+
+		// simulate some work
+		mockClock.Sleep(functionRuntime)
+
+		if !lastCall.Equal(nullTime) {
+			delta := called.Sub(lastCall)
+			calledRelativeTimes = append(calledRelativeTimes, delta)
+		}
+		lastCall = called
+
+		if callCount == 2 {
+			// only call this at the second call,
+			// this is useful to test
+			// StopOnErrors() option
+			return false, errAtSecondCall
+		}
+		return false, errDefault
+	}
+	// This uses the mock clock virtual timeout
+	ctx, cancel := mockClock.WithTimeout(context.Background(), flags.deadline)
+	defer cancel()
+
+	opts := flags.opts
+	opts = append(opts, UseClock(mockClock))
+
+	go func(ctx context.Context) {
+		// we need to progress the mock clock in a
+		// separate routine
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				mockClock.Add(10 * time.Millisecond)
+			}
+		}
+	}(ctx)
+
+	_, err := FunctionCall(ctx, fn, opts...)
+	if flags.expectedErr != nil {
+		assert.Error(t, err, flags.expectedErr.Error())
+	} else {
+		assert.NilError(t, err)
+	}
+	if flags.expectedTimes != nil {
+		assert.DeepEqual(
+			t,
+			flags.expectedTimes,
+			calledRelativeTimes,
+			comparer.DurationComparerStrict,
+		)
+	}
+}

--- a/rolling-shutter/p2p/handler.go
+++ b/rolling-shutter/p2p/handler.go
@@ -178,7 +178,7 @@ func (h *P2PHandler) hasHandler() bool {
 
 func (h *P2PHandler) runHandleMessages(ctx context.Context) error {
 	// This will consume incoming messages and dispatch them to the registered handler functions
-	// If the handler return messages, then they will be sent to the broadcast
+	// If the handler returns messages, then they will be sent to the broadcast
 	for {
 		select {
 		case msg, ok := <-h.P2P.GossipMessages:


### PR DESCRIPTION
closes #335 

### What is implemented in this PR?
1) A new routine is added to the collator which closes batches at a constant interval by calling `batcher.CloseBatch()` and afterwards trying to initiate the batchers chain-state by spamming `batcher.EnsureChainState()`
2) `medley.retry` now has the `StopOnError` and `NumberOfRetries(-1)` configuration options
3) a fix in the `retry.retrier.iterator` implementation + minor changes in the containing package
4) expose error instances from `batcher` publicly