### PR TITLE
Make mocksequencer available from babashka task 

### DIFF
--- a/play/README.md
+++ b/play/README.md
@@ -26,6 +26,17 @@ export ROLLING_SHUTTER_GENESIS_KEYPER=0x440Dc6F164e9241F04d282215ceF2780cd0B755e
 6. bb k 1
 7. bb k 2
 
+## full test setup
+
+1.  bb init; bb chain
+2.  bb node
+3.  bb peer collator.toml mock.toml keyper-0.toml keyper-1.toml keyper-2.toml;
+    bb boot; bb sequencer
+4.  bb k 0
+5.  bb k 1
+6.  bb k 2
+7.  bb collator
+
 ## Whole system tests
 
 Make sure you have java jdk 17 as well as clojure installed.

--- a/play/bb.edn
+++ b/play/bb.edn
@@ -143,7 +143,6 @@
       [& args]
       (run-process (cons 'rolling-shutter args))))
 
-
   -godoc:idx
   {:depends [-install:godoc]
    :task (let [path (src-file "godoc.idx")]
@@ -343,10 +342,23 @@
    :depends [build -mocknode-subcommand]
    :task (play/generate-config -mocknode-subcommand)}
 
+  ;; --------------------------------------
+  ;; -- mock-sequencer
+
+  -mocksequencer-subcommand
+  {:depends []
+   :task (play/mocksequencer-subcommand)}
+
+  genconfig:mocksequencer
+  {:doc "Generate mocksequencer config"
+   :depends [build -mocksequencer-subcommand]
+   :task (play/generate-config -mocksequencer-subcommand)}
+
+  ;; --------------------------------------
   ;; -- general tasks
   genconfig
   {:doc "Generate configs"
-   :depends [genconfig:keypers genconfig:mock]}
+   :depends [genconfig:keypers genconfig:mock genconfig:mocksequencer]}
 
   peer
   {:doc "Add nodes as peers of each other"
@@ -411,7 +423,7 @@
   {:doc "Run godoc"
    :depends [-godoc:idx]
    :task (do
-           (print "===============> Starting godoc. Please wait a few seconds for the browser to open!\n" )
+           (print "===============> Starting godoc. Please wait a few seconds for the browser to open!\n")
            (future
              (Thread/sleep 4000)
              (browse/browse-url "http://localhost:6060/"))
@@ -445,6 +457,10 @@
    :depends [build genconfig:mock]
    :task (run-process (play/subcommand-run genconfig:mock))}
 
+  sequencer
+  {:doc "Run mocksequencer"
+   :depends [build genconfig:mocksequencer]
+   :task (run-process (play/subcommand-run genconfig:mocksequencer))}
 
   clean
   {:doc "Remove config files and chain related files"
@@ -453,6 +469,7 @@
            (fs/delete-tree "testchain")
            (doseq [{:subcommand/keys [cfgfile]} (concat -keyper-subcommands
                                                         [(play/mocknode-subcommand)
+                                                         (play/mocksequencer-subcommand)
                                                          -collator-subcommand])]
              (fs/delete-if-exists cfgfile)))}
   ci-gen sht.play/ci-gen}}

--- a/rolling-shutter/cmd/collator/collator.go
+++ b/rolling-shutter/cmd/collator/collator.go
@@ -147,6 +147,7 @@ func exampleConfig() (*config.Config, error) {
 	}
 	return &config.Config{
 		EthereumURL:         "http://127.0.0.1:8545/",
+		ContractsURL:        "http://127.0.0.1:8545/",
 		DeploymentDir:       "./deployments/localhost/",
 		ListenAddress:       p2p.MustMultiaddr("/ip4/127.0.0.1/tcp/2000"),
 		PeerMultiaddrs:      []multiaddr.Multiaddr{},

--- a/rolling-shutter/cmd/keyper/keyper.go
+++ b/rolling-shutter/cmd/keyper/keyper.go
@@ -74,6 +74,7 @@ func readKeyperConfig() (keyper.Config, error) {
 	viper.SetEnvPrefix("KEYPER")
 	viper.BindEnv("ShuttermintURL")
 	viper.BindEnv("EthereumURL")
+	viper.BindEnv("ContractsURL")
 	viper.BindEnv("DeploymentDir")
 	viper.BindEnv("SigningKey")
 	viper.BindEnv("ValidatorSeed")
@@ -179,7 +180,7 @@ func exampleConfig() (*keyper.Config, error) {
 	cfg := &keyper.Config{
 		ShuttermintURL:     "http://localhost:26657",
 		EthereumURL:        "http://127.0.0.1:8545/",
-		L2URL:              "http://127.0.0.1:8547/",
+		ContractsURL:       "http://127.0.0.1:8555/",
 		DeploymentDir:      "./deployments/localhost/",
 		DKGPhaseLength:     30,
 		DKGStartBlockDelta: 12000,

--- a/rolling-shutter/cmd/mocksequencer/mocksequencer.go
+++ b/rolling-shutter/cmd/mocksequencer/mocksequencer.go
@@ -1,31 +1,30 @@
 package mocksequencer
 
 import (
+	"bytes"
 	"context"
 	"math/big"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/rs/zerolog/pkgerrors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/cmd/shversion"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/mocksequencer"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/mocksequencer/rpc"
 )
 
 var (
-	l1RPCURL     string
-	sequencerURL string
-	chainID      uint64
-	debug        bool
-	admin        bool
+	outputFile string
+	cfgFile    string
 )
-
-type Config struct{}
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -33,21 +32,97 @@ func Cmd() *cobra.Command {
 		Short: "Run a node that pretends to be a sequencer",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return mockSequencerMain()
+			config, err := readConfig()
+			if err != nil {
+				return err
+			}
+			return mockSequencerMain(&config)
 		},
 	}
-	cmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "debug mode (higher log verbosity)")
-	cmd.PersistentFlags().BoolVarP(&admin, "admin", "", true, "expose the 'admin_' RPC namespace methods")
-	cmd.PersistentFlags().StringVarP(&l1RPCURL, "l1", "l", "http://localhost:8545", "layer-1 node JSON RPC endpoint")
-	cmd.PersistentFlags().StringVarP(&sequencerURL, "rpc", "r", ":8545", "url of the sequencer's JSON RPC endpoint")
-	cmd.PersistentFlags().Uint64VarP(&chainID, "chain-id", "c", 4242, "the chain-id")
+	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
+	cmd.AddCommand(generateConfigCmd())
 	return cmd
 }
 
-func mockSequencerMain() error {
+func exampleConfig() *mocksequencer.Config {
+	return &mocksequencer.Config{
+		HTTPListenAddress:    ":8555",
+		EthereumURL:          "http://localhost:8545",
+		ChainID:              42,
+		MaxBlockDeviation:    5,
+		EthereumPollInterval: 1,
+		Admin:                true,
+		Debug:                true,
+	}
+}
+
+func generateConfig() error {
+	config := exampleConfig()
+	buf := &bytes.Buffer{}
+	err := config.WriteTOML(buf)
+	if err != nil {
+		return err
+	}
+	return medley.SecureSpit(outputFile, buf.Bytes())
+}
+
+func generateConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generate-config",
+		Short: "Generate a mock sequencer configuration file",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generateConfig()
+		},
+	}
+	cmd.PersistentFlags().StringVar(&outputFile, "output", "", "output file")
+	cmd.MarkPersistentFlagRequired("output")
+
+	return cmd
+}
+
+func readConfig() (mocksequencer.Config, error) {
+	viper.SetEnvPrefix("SEQUENCER")
+	viper.BindEnv("EthereumURL")
+
+	viper.SetDefault("HTTPListenAddress", "localhost:8555")
+	viper.SetDefault("EthereumURL", "http://localhost:8545")
+
+	viper.SetDefault("ChainID", uint64(42))
+	viper.SetDefault("MaxBlockDeviation", uint64(5))
+	viper.SetDefault("EthereumPollInterval", uint64(1))
+	viper.SetDefault("Admin", true)
+	viper.SetDefault("Debug", true)
+
+	config := mocksequencer.Config{}
+
+	viper.AddConfigPath("$HOME/.config/shutter")
+	viper.SetConfigName("mocksequencer")
+	viper.SetConfigType("toml")
+	viper.SetConfigFile(cfgFile)
+
+	err := viper.ReadInConfig()
+	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		// Config file not found
+		if cfgFile != "" {
+			return config, err
+		}
+	} else if err != nil {
+		return config, err // Config file was found but another error was produced
+	}
+
+	err = config.Unmarshal(viper.GetViper())
+	if err != nil {
+		return config, err
+	}
+
+	return config, nil
+}
+
+func mockSequencerMain(config *mocksequencer.Config) error {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	if debug {
+	if config.Debug {
 		zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
@@ -64,13 +139,20 @@ func mockSequencerMain() error {
 		cancel()
 	}()
 
-	sequencer := mocksequencer.New(new(big.Int).SetUint64(chainID), sequencerURL, l1RPCURL)
+	l1PollInterval := time.Duration(config.EthereumPollInterval) * time.Second
+	sequencer := mocksequencer.New(
+		new(big.Int).SetUint64(config.ChainID),
+		config.HTTPListenAddress,
+		config.EthereumURL,
+		l1PollInterval,
+		config.MaxBlockDeviation,
+	)
 
 	services := []mocksequencer.RPCService{
 		&rpc.EthService{},
 		&rpc.ShutterService{},
 	}
-	if admin {
+	if config.Admin {
 		services = append(services, &rpc.AdminService{})
 	}
 	err := sequencer.ListenAndServe(

--- a/rolling-shutter/collator/collator.go
+++ b/rolling-shutter/collator/collator.go
@@ -282,7 +282,7 @@ func (c *collator) getBatchConfirmation(ctx context.Context) (uint64, error) {
 func getBlockNumber(ctx context.Context, client *ethclient.Client) (uint64, error) {
 	blk, err := retry.FunctionCall(ctx, func(ctx context.Context) (uint64, error) {
 		return client.BlockNumber(ctx)
-	})
+	}, retry.LogCaptureStackFrameContext())
 	if err != nil {
 		return 0, err
 	}

--- a/rolling-shutter/collator/collator.go
+++ b/rolling-shutter/collator/collator.go
@@ -67,11 +67,11 @@ func Run(ctx context.Context, cfg config.Config) error {
 	if err != nil {
 		return err
 	}
-	l2Client, err := ethclient.Dial(cfg.SequencerURL)
+	contractsClient, err := ethclient.Dial(cfg.ContractsURL)
 	if err != nil {
 		return err
 	}
-	contracts, err := deployment.NewContracts(l2Client, cfg.DeploymentDir)
+	contracts, err := deployment.NewContracts(contractsClient, cfg.DeploymentDir)
 	if err != nil {
 		return err
 	}

--- a/rolling-shutter/collator/config/config.go
+++ b/rolling-shutter/collator/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 
 	EthereumURL       string
 	SequencerURL      string
+	ContractsURL      string
 	DeploymentDir     string
 	DatabaseURL       string
 	HTTPListenAddress string
@@ -53,6 +54,9 @@ HTTPListenAddress = "{{ .HTTPListenAddress }}"
 
 # JSON RPC endpoint of the sequencer to which batches will be submitted
 SequencerURL = "{{ .SequencerURL }}"
+
+# JSON RPC endpoint of the node where the contracts are deployed
+ContractsURL = "{{ .ContractsURL }}"
 
 # p2p configuration
 ListenAddress   = "{{ .ListenAddress }}"

--- a/rolling-shutter/collator/epochhandling.go
+++ b/rolling-shutter/collator/epochhandling.go
@@ -191,6 +191,7 @@ func (c *collator) closeBatchesTicker(ctx context.Context, interval time.Duratio
 				fnCloseBatch,
 				retry.Interval(retryPollInterval),
 				retry.NumberOfRetries(-1),
+				retry.LogCaptureStackFrameContext(),
 			)
 			if err != nil {
 				if ctx.Err() != nil {
@@ -214,6 +215,7 @@ func (c *collator) closeBatchesTicker(ctx context.Context, interval time.Duratio
 				retry.Interval(retryPollInterval),
 				retry.NumberOfRetries(-1),
 				retry.StopOnErrors(batcher.ErrBatchAlreadyExists),
+				retry.LogCaptureStackFrameContext(),
 			)
 			if err == batcher.ErrBatchAlreadyExists {
 				// something is seriously wrong

--- a/rolling-shutter/keyper/config.go
+++ b/rolling-shutter/keyper/config.go
@@ -23,7 +23,7 @@ import (
 type Config struct {
 	ShuttermintURL string
 	EthereumURL    string
-	L2URL          string
+	ContractsURL   string
 	DatabaseURL    string
 	DeploymentDir  string
 
@@ -47,8 +47,10 @@ const configTemplate = `# Shutter keyper config
 # Peer identity: /p2p/{{ .P2PKey | P2PKeyPublic}}
 
 ShuttermintURL		= "{{ .ShuttermintURL }}"
+# The layer 1 JSON RPC endpoitn
 EthereumURL         = "{{ .EthereumURL }}"
-L2URL               = "{{ .L2URL }}"
+# The JSON RPC endpoint where the contracts are accessible
+ContractsURL               = "{{ .ContractsURL }}"
 DeploymentDir       = "{{ .DeploymentDir }}"
 
 # DatabaseURL looks like postgres://username:password@localhost:5432/database_name

--- a/rolling-shutter/keyper/keyper.go
+++ b/rolling-shutter/keyper/keyper.go
@@ -86,7 +86,7 @@ func Run(ctx context.Context, config Config) error {
 	if err != nil {
 		return err
 	}
-	l2Client, err := ethclient.Dial(config.L2URL)
+	l2Client, err := ethclient.Dial(config.ContractsURL)
 	if err != nil {
 		return err
 	}

--- a/rolling-shutter/medley/retry/retry.go
+++ b/rolling-shutter/medley/retry/retry.go
@@ -54,7 +54,7 @@ func (r *retrier) logWithContext(e *zerolog.Event) *zerolog.Event {
 }
 
 func (r *retrier) logError(err error, msg string) {
-	e := log.Error().Err(err)
+	e := log.Debug().Err(err)
 	r.logWithContext(e).Msg(msg)
 }
 
@@ -112,7 +112,7 @@ func FunctionCall[T any](ctx context.Context, fn RetriableFunction[T], opts ...O
 		select {
 		case _, ok := <-retry:
 			if !ok {
-				retrier.logWithContext(log.Info()).Msg("retry limit reached")
+				retrier.logWithContext(log.Debug()).Msg("retry limit reached")
 				return null, err
 			}
 			var result T

--- a/rolling-shutter/medley/retry/retry.go
+++ b/rolling-shutter/medley/retry/retry.go
@@ -47,7 +47,7 @@ func (r *retrier) logWithContext(e *zerolog.Event) *zerolog.Event {
 		e = e.Str("id", r.identifier)
 	}
 
-	if r.identifier != "" {
+	if r.executionContext != "" {
 		e = e.Str("context", r.executionContext)
 	}
 	return e

--- a/rolling-shutter/mocksequencer/config.go
+++ b/rolling-shutter/mocksequencer/config.go
@@ -11,7 +11,7 @@ import (
 
 var configTemplate = `# Shutter mock sequencer config
 # JSON-RPC endpoint exposed to clients
-HTTPListenAddress = "{{ .ListenURL }}"
+HTTPListenAddress = "{{ .HTTPListenAddress }}"
 
 # Layer1 JSON-RPC endpoint
 EthereumURL = "{{ .EthereumURL }}"

--- a/rolling-shutter/mocksequencer/config.go
+++ b/rolling-shutter/mocksequencer/config.go
@@ -1,0 +1,52 @@
+package mocksequencer
+
+import (
+	"io"
+	"text/template"
+
+	"github.com/spf13/viper"
+
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley"
+)
+
+var configTemplate = `# Shutter mock sequencer config
+# JSON-RPC endpoint exposed to clients
+HTTPListenAddress = "{{ .ListenURL }}"
+
+# Layer1 JSON-RPC endpoint
+EthereumURL = "{{ .EthereumURL }}"
+
+# Chain config
+ChainID = {{ .ChainID }}
+MaxBlockDeviation = {{ .MaxBlockDeviation }}
+EthereumPollInterval = {{ .EthereumPollInterval }}
+
+# Debug
+Admin = {{ .Admin }}
+Debug = {{ .Debug }}
+
+`
+
+var tmpl *template.Template = medley.MustBuildTemplate("mocksequencer", configTemplate)
+
+type Config struct {
+	HTTPListenAddress string
+	EthereumURL       string
+
+	ChainID              uint64
+	MaxBlockDeviation    uint64
+	EthereumPollInterval uint64
+
+	Admin bool
+	Debug bool
+}
+
+// WriteTOML writes a toml configuration file with the given config.
+func (config *Config) WriteTOML(w io.Writer) error {
+	return tmpl.Execute(w, config)
+}
+
+// Unmarshal unmarshals a mocksequencer Config from the the given Viper object.
+func (config *Config) Unmarshal(v *viper.Viper) error {
+	return v.Unmarshal(config)
+}

--- a/rolling-shutter/mocksequencer/mocksequencer_test/decryption_test.go
+++ b/rolling-shutter/mocksequencer/mocksequencer_test/decryption_test.go
@@ -11,7 +11,6 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/epochid"
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/mocksequencer"
 )
 
 func TestServerDecryption(t *testing.T) {
@@ -36,7 +35,7 @@ func TestServerDecryption(t *testing.T) {
 	l1BlockNumber := uint64(42)
 
 	fixtures.L1Service.setBlockNumber(l1BlockNumber)
-	time.Sleep(mocksequencer.L1PollInterVal + 200*time.Millisecond)
+	time.Sleep(sequencerL1PollInterval + 200*time.Millisecond)
 	// HACK this is not the best way to synchronize.
 	// Better would be to keep a last-time-polled counter in the sequencer
 	// and here just wait for the next one

--- a/rolling-shutter/mocksequencer/mocksequencer_test/fixtures_test.go
+++ b/rolling-shutter/mocksequencer/mocksequencer_test/fixtures_test.go
@@ -24,7 +24,11 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/mocksequencer/rpc"
 )
 
-var ADDRESS1 common.Address = common.BigToAddress(big.NewInt(1))
+var (
+	ADDRESS1                   common.Address = common.BigToAddress(big.NewInt(1))
+	sequencerL1PollInterval                   = time.Second
+	sequencerMaxBlockDeviation uint64         = 5
+)
 
 var BigIntComparer gocmp.Option = gocmp.Comparer(func(x, y *big.Int) bool {
 	if x == nil || y == nil {
@@ -157,7 +161,13 @@ func NewFixtures(ctx context.Context, numSenders int, serveHTTP bool) (fx *Fixtu
 	// right now the tests will fail if any of those ports
 	// are already in use
 	l1ServerURL := "http://localhost:8555"
-	fx.Sequencer = mocksequencer.New(fx.ChainID, ":8545", l1ServerURL)
+	fx.Sequencer = mocksequencer.New(
+		fx.ChainID,
+		":8545",
+		l1ServerURL,
+		sequencerL1PollInterval,
+		sequencerMaxBlockDeviation,
+	)
 
 	// set the sequencer internal activation-block based values
 	fx.Sequencer.EonKeys.Set(eonPubKey, 0)

--- a/rolling-shutter/mocksequencer/rpc/service_eth.go
+++ b/rolling-shutter/mocksequencer/rpc/service_eth.go
@@ -48,6 +48,7 @@ func (s *EthService) GetBalance(address common.Address, blockNrOrHash ethrpc.Blo
 	return balance, nil
 }
 
-func (s *EthService) ChainID() *hexutil.Big {
+//nolint:var-naming,revive,stylecheck
+func (s *EthService) ChainId() *hexutil.Big {
 	return (*hexutil.Big)(s.processor.ChainID())
 }

--- a/rolling-shutter/mocksequencer/rpc/service_eth.go
+++ b/rolling-shutter/mocksequencer/rpc/service_eth.go
@@ -1,14 +1,47 @@
 package rpc
 
 import (
+	"context"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/mocksequencer"
 	rpcerrors "github.com/shutter-network/rolling-shutter/rolling-shutter/mocksequencer/errors"
 )
+
+// rpcMarshalHeader converts the given header to the RPC output .
+func rpcMarshalHeader(head *ethtypes.Header) map[string]interface{} {
+	result := map[string]interface{}{
+		"number":           (*hexutil.Big)(head.Number),
+		"hash":             head.Hash(),
+		"parentHash":       head.ParentHash,
+		"nonce":            head.Nonce,
+		"mixHash":          head.MixDigest,
+		"sha3Uncles":       head.UncleHash,
+		"logsBloom":        head.Bloom,
+		"stateRoot":        head.Root,
+		"miner":            head.Coinbase,
+		"difficulty":       (*hexutil.Big)(head.Difficulty),
+		"extraData":        hexutil.Bytes(head.Extra),
+		"size":             hexutil.Uint64(head.Size()),
+		"gasLimit":         hexutil.Uint64(head.GasLimit),
+		"gasUsed":          hexutil.Uint64(head.GasUsed),
+		"timestamp":        hexutil.Uint64(head.Time),
+		"transactionsRoot": head.TxHash,
+		"receiptsRoot":     head.ReceiptHash,
+	}
+
+	if head.BaseFee != nil {
+		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
+	}
+
+	return result
+}
 
 type EthService struct {
 	processor *mocksequencer.Sequencer
@@ -51,4 +84,38 @@ func (s *EthService) GetBalance(address common.Address, blockNrOrHash ethrpc.Blo
 //nolint:var-naming,revive,stylecheck
 func (s *EthService) ChainId() *hexutil.Big {
 	return (*hexutil.Big)(s.processor.ChainID())
+}
+
+func (s *EthService) GetBlockByNumber(_ context.Context, blockNumber ethrpc.BlockNumber, _ bool) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	s.processor.Mux.RLock()
+	defer s.processor.Mux.RUnlock()
+
+	block, err := s.processor.GetBlock(ethrpc.BlockNumberOrHashWithNumber(blockNumber))
+	if err != nil {
+		err := errors.New("header for blockNumber not found")
+		return nil, rpcerrors.Default(err)
+	}
+
+	header := &ethtypes.Header{
+		ParentHash: [32]byte{},
+		UncleHash:  ethtypes.EmptyUncleHash,
+		// Coinbase:    [20]byte{}, // optional
+		Root:        ethtypes.EmptyRootHash,
+		TxHash:      ethtypes.EmptyRootHash,
+		ReceiptHash: [32]byte{},
+		Bloom:       [256]byte{},
+		Difficulty:  &big.Int{},
+		Number:      &big.Int{},
+		GasLimit:    block.GasLimit,
+		GasUsed:     0,
+		Time:        0,
+		Extra:       []byte{},
+		// MixDigest:   [32]byte{}, // optional
+		// Nonce:       [8]byte{},  // optional
+		BaseFee: new(big.Int).Set(block.BaseFee),
+	}
+
+	result = rpcMarshalHeader(header)
+	return result, nil
 }


### PR DESCRIPTION
Fixes #343 
- fix `eth_ChainId` RPC method naming
- adds `eth_getBlockByNumber` endpoint for collator queries
- changes CLI argument based options to config file based options
- intializes the collators database on first startup for batch handling