### PR TITLE
Fix #348 and additional tests

### DIFF
--- a/rolling-shutter/app/app.go
+++ b/rolling-shutter/app/app.go
@@ -464,10 +464,11 @@ func (app *ShutterApp) maybeStartEon(eon uint64) (*DKGInstance, bool) {
 
 	threshold := int(dkg.Config.Threshold)
 	success, ok := dkg.SuccessVoting.Outcome(threshold)
-	if !ok || success {
+	// dismiss votes for Eon that was voted on successfully already
+	outdatedEon := app.EONCounter > eon
+	if !ok || success || outdatedEon {
 		return nil, false
 	}
-
 	return app.StartDKG(dkg.Config), true
 }
 


### PR DESCRIPTION
See #348 

This also adds additional tests to check for exact Eon matches in the Keyper's databases in
order to avoid missing unexpected additional Eons in the tests