### PR TITLE
Do not send close batch if we have no eon public key

### DIFF
--- a/play/src/sht/collator_test.clj
+++ b/play/src/sht/collator_test.clj
@@ -53,6 +53,11 @@
   rows-empty?
   "no decryption trigger should have been generated")
 
+(def-check-query :collator/decryption-trigger
+  ["select * from decryption_trigger"]
+  rows-not-empty?
+  "decryption trigger should have been generated")
+
 
 (defn test-collator-basic
   [{:keys [num-keypers] :as conf}]
@@ -100,6 +105,10 @@
                 (for [keyper (range num-keypers)]
                   {:check :keyper/non-zero-activation-block
                    :keyper/num keyper})
+                {:check :loop/until
+                 :loop/description "decryption trigger should be generated"
+                 :loop/timeout-ms (* 6 1000)
+                 :loop/checks [{:check :collator/decryption-trigger}]}
                 ;; {:check :loop/forever}
                 ]})
 

--- a/rolling-shutter/collator/batcher/batcher.go
+++ b/rolling-shutter/collator/batcher/batcher.go
@@ -232,6 +232,13 @@ func (btchr *Batcher) closeBatchImpl(ctx context.Context, db *cltrdb.Queries, l1
 		return err
 	}
 
+	// Lookup the current eon public key for the given block.
+	_, err = db.FindEonPublicKeyForBlock(ctx, l1blockNumber)
+	if err != nil {
+		log.Info().Int64("l1BlockNumber", l1blockNumber).Msg("no eon public key found")
+		return err
+	}
+
 	// Mark all new TXs as rejected
 	err = db.RejectNewTransactions(ctx, nextBatchEpochID.Bytes())
 	if err != nil {

--- a/rolling-shutter/collator/batcher/batcher_test.go
+++ b/rolling-shutter/collator/batcher/batcher_test.go
@@ -109,6 +109,7 @@ func TestCloseBatchIntegration(t *testing.T) {
 	var err error
 	ctx := context.Background()
 	fixtures := Setup(ctx, t, DefaultTestParams())
+	fixtures.AddEonPublicKey(ctx, t)
 	t.Run("Init", func(t *testing.T) {
 		assert.Check(t, fixtures.Batcher.nextBatchChainState != nil, "nextBatchChainState field not initialized")
 	})
@@ -151,7 +152,7 @@ func TestOpenNextBatch(t *testing.T) {
 	var err error
 	ctx := context.Background()
 	fixtures := Setup(ctx, t, DefaultTestParams())
-
+	fixtures.AddEonPublicKey(ctx, t)
 	err = fixtures.Batcher.CloseBatch(ctx)
 	assert.NilError(t, err)
 	assert.Check(t, fixtures.Batcher.nextBatchChainState == nil, "nextBatchChainState field initialized")
@@ -206,7 +207,7 @@ func TestDecryptionTriggerGeneratedIntegration(t *testing.T) {
 	var err error
 	ctx := context.Background()
 	fixtures := Setup(ctx, t, DefaultTestParams())
-
+	fixtures.AddEonPublicKey(ctx, t)
 	nextBatchEpoch, _, err := batchhandler.GetNextBatch(ctx, fixtures.DB)
 	assert.NilError(t, err)
 	nextBatchIndex := nextBatchEpoch.Uint64()

--- a/rolling-shutter/collator/batcher/setup_test.go
+++ b/rolling-shutter/collator/batcher/setup_test.go
@@ -183,6 +183,19 @@ func Setup(ctx context.Context, t *testing.T, params TestParams) *Fixture {
 	}
 }
 
+func (fix *Fixture) AddEonPublicKey(ctx context.Context, t *testing.T) {
+	t.Helper()
+	hash := []byte{1, 2, 3}
+	pubkey := []byte{4, 5, 6}
+	err := fix.DB.InsertEonPublicKeyCandidate(ctx, cltrdb.InsertEonPublicKeyCandidateParams{
+		Hash:         hash,
+		EonPublicKey: pubkey,
+	})
+	assert.NilError(t, err)
+	err = fix.DB.ConfirmEonPublicKey(ctx, hash)
+	assert.NilError(t, err)
+}
+
 func (fix *Fixture) MakeTx(t *testing.T, accountIndex, batchIndex, nonce, gas int) ([]byte, []byte) { //nolint:unparam
 	t.Helper()
 	assert.Check(t, accountIndex >= 0 && accountIndex < numAccounts)


### PR DESCRIPTION
We lookup the eon public key before closing a batch and reject doing that if we don't have an eon public key.

See #347 