### PR TITLE
Upgrade `libp2p-core` imports to monorepo package imports

### DIFF
--- a/rolling-shutter/cmd/collator/collator.go
+++ b/rolling-shutter/cmd/collator/collator.go
@@ -11,7 +11,7 @@ import (
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/jackc/pgx/v4/pgxpool"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"

--- a/rolling-shutter/cmd/mocknode/mocknode.go
+++ b/rolling-shutter/cmd/mocknode/mocknode.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"

--- a/rolling-shutter/cmd/snapshot/snapshot.go
+++ b/rolling-shutter/cmd/snapshot/snapshot.go
@@ -10,7 +10,7 @@ import (
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/jackc/pgx/v4/pgxpool"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"

--- a/rolling-shutter/keyper/config.go
+++ b/rolling-shutter/keyper/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/mitchellh/mapstructure"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"

--- a/rolling-shutter/keyper/keyper_test.go
+++ b/rolling-shutter/keyper/keyper_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"google.golang.org/protobuf/proto"
 	"gotest.tools/assert"
 

--- a/rolling-shutter/medley/comparer/comparer.go
+++ b/rolling-shutter/medley/comparer/comparer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	gocmp "github.com/google/go-cmp/cmp"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 )
 
 // P2PPrivKeyComparer is a gocmp comparer for use with gotest.tools/assert.DeepEqual.

--- a/rolling-shutter/medley/decodehooks.go
+++ b/rolling-shutter/medley/decodehooks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	multiaddr "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 )

--- a/rolling-shutter/medley/template.go
+++ b/rolling-shutter/medley/template.go
@@ -7,8 +7,8 @@ import (
 	"text/template"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/peer"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	multiaddr "github.com/multiformats/go-multiaddr"
 
 	"github.com/shutter-network/shutter/shlib/shcrypto"

--- a/rolling-shutter/mocknode/config.go
+++ b/rolling-shutter/mocknode/config.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"text/template"
 
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/mitchellh/mapstructure"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/spf13/viper"

--- a/rolling-shutter/p2p/handler.go
+++ b/rolling-shutter/p2p/handler.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"

--- a/rolling-shutter/p2p/p2p.go
+++ b/rolling-shutter/p2p/p2p.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 
 	"github.com/libp2p/go-libp2p"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"

--- a/rolling-shutter/p2p/p2p_test.go
+++ b/rolling-shutter/p2p/p2p_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/rs/zerolog/log"
 	"gotest.tools/assert"

--- a/rolling-shutter/p2p/params.go
+++ b/rolling-shutter/p2p/params.go
@@ -3,8 +3,8 @@ package p2p
 import (
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 func peerScoreParams() *pubsub.PeerScoreParams {

--- a/rolling-shutter/p2p/peers.go
+++ b/rolling-shutter/p2p/peers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog/log"
 )
 

--- a/rolling-shutter/p2p/topic.go
+++ b/rolling-shutter/p2p/topic.go
@@ -3,8 +3,8 @@ package p2p
 import (
 	"context"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )

--- a/rolling-shutter/snapshot/config.go
+++ b/rolling-shutter/snapshot/config.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
-	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	p2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/mitchellh/mapstructure"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"


### PR DESCRIPTION
The libp2p-core library is being deprecated and is now placed in the main libp2p monorepo.
This also caused some issues updating to golang 1.10 because auf a transient libp2p-core library (IIRC).