### PR TITLE
Fix batcher's next-batch always initialized to "1"

### DIFF
--- a/rolling-shutter/collator/batcher/setup_test.go
+++ b/rolling-shutter/collator/batcher/setup_test.go
@@ -156,14 +156,6 @@ func Setup(ctx context.Context, t *testing.T, params TestParams) *Fixture {
 	ethL2.SetChainID(chainID)
 	ethL2.SetBlock(params.BaseFee, gasLimit, "latest")
 
-	// set initial ("next") epoch id and block number manually,
-	// this is usually done in the collator and not in the handler
-
-	err := db.SetNextBatch(ctx, cltrdb.SetNextBatchParams{
-		EpochID:       params.InitialEpochID.Bytes(),
-		L1BlockNumber: 42,
-	})
-	assert.NilError(t, err)
 	batcher, err := NewBatcher(ctx, cfg, dbpool)
 	assert.NilError(t, err)
 	return &Fixture{


### PR DESCRIPTION
Before, the next batch in the database was always initialized to 1 on startup. This was also the case when the sequencer already was at a higher batch number.
This caused a non-recovering error-condition in the `initChainState` method, which was masked in the tests by manually setting the  db's next-batch value during fixture creation.

Now, the collator queries the batch-number of the sequencer on startup, as long as the collator does not have a next-batch set in the DB already.