### PR TITLE
Add wait() for collator deployments

### DIFF
--- a/contracts/deploy/515_configure_collator.js
+++ b/contracts/deploy/515_configure_collator.js
@@ -29,8 +29,10 @@ module.exports = async function (hre) {
     console.log("Collator set already added");
     configSetIndex = lastSetIndex;
   } else {
-    await collator.add(collatorAddress);
-    await collator.append();
+    const tx1 = await collator.add(collatorAddress);
+    await tx1.wait();
+    const tx2 = await collator.append();
+    await tx2.wait();
     configSetIndex = lastSetIndex + 1;
   }
 


### PR DESCRIPTION
The deployment script `515_configure_collator.js` failed against a go ethereum `--dev` instance with the error
```
snapshutter-deploy-contracts-1  | Error: ERROR processing /contracts/deploy/515_configure_collator.js:
snapshutter-deploy-contracts-1  | Error: cannot estimate gas; transaction may fail or may require manual gas limit [ See: https://links.ethers.org/v5-errors-UNPREDICTABLE_GAS_LIMIT ] (reason="execution reverted: No appended set in seq corresponding to config's set index", method="estimateGas", transaction={"from":"0xF1c0084dE255E86ba39bF80f99dE5a26F9f9a1FA","to":"0x9F0bbBcd413E9d5C660bD99F4bBed0211F4e25A7","data":"0x79f7809900000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000001","accessList":null}, error={"name":"ProviderError","_stack":"ProviderError: execution reverted: No appended set in seq corresponding to config's set index\n    at HttpProvider.request (/contracts/node_modules/hardhat/src/internal/core/providers/http.ts:88:21)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at EthersProviderWrapper.send (/contracts/node_modules/hardhat-deploy-ethers/src/internal/ethers-provider-wrapper.ts:13:20)","code":3,"_isProviderError":true,"data":"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003a4e6f20617070656e6465642073657420696e2073657120636f72726573706f6e64696e6720746f20636f6e66696727732073657420696e646578000000000000"}, code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.7.2)
```

By adding extra `wait()` calls for contract calls, this error can be circumvented.