### PR TITLE
Fix keyper's `handleOnChainKeyperSetChanges` not using current blocknumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .vscode
 .direnv
+.devenv
 .lsp
 log
 node_modules
 docker/data
+temp
+result

--- a/contracts/lib/configure-keypers.js
+++ b/contracts/lib/configure-keypers.js
@@ -43,7 +43,7 @@ async function configure_keypers(keyperAddrs) {
 
   const cfg = await ethers.getContract("KeyperConfig");
   const currentBlock = await ethers.provider.getBlockNumber();
-  const activationBlockNumber = currentBlock + 10;
+  const activationBlockNumber = currentBlock + 15;
 
   const activeConfig = await cfg.getActiveConfig(activationBlockNumber);
   if (activeConfig[1].toNumber() === configSetIndex) {

--- a/play/.gitignore
+++ b/play/.gitignore
@@ -13,3 +13,4 @@
 /ci-bb.edn
 *.jar
 /target/
+.clj-kondo

--- a/play/src/sht/play.clj
+++ b/play/src/sht/play.clj
@@ -213,6 +213,7 @@
                  :cfgfile (format "keyper-%s.toml" n)
                  :toml-edits {"DatabaseURL" (format "postgres:///%s" db)
                               "DKGPhaseLength" 8
+                              "DKGStartBlockDelta" 5
                               "ListenAddresses" [(format "/ip4/127.0.0.1/tcp/%d" p2p-port)]
                               "HTTPEnabled" true
                               "HTTPListenAddress" (format ":%d" (+ 24000 n))

--- a/rolling-shutter/keyper/config.go
+++ b/rolling-shutter/keyper/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	EncryptionKey            *ecies.PrivateKey
 	P2PKey                   p2pcrypto.PrivKey
 	DKGPhaseLength           uint64 // in shuttermint blocks
-	DKGStartBlockDelta       int64
+	DKGStartBlockDelta       uint64
 	ListenAddresses          []multiaddr.Multiaddr
 	CustomBootstrapAddresses []peer.AddrInfo
 	Environment              p2p.Environment

--- a/rolling-shutter/keyper/keyper.go
+++ b/rolling-shutter/keyper/keyper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/fx"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/kprapi"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/smobserver"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/eventsyncer"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/retry"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
@@ -247,8 +248,10 @@ func (kpr *keyper) handleOnChainKeyperSetChanges(
 		return nil
 	}
 
-	// FIXME this could theoretically be negative
-	activationBlockNumber := uint64(keyperSet.ActivationBlockNumber)
+	activationBlockNumber, err := medley.Int64ToUint64Safe(keyperSet.ActivationBlockNumber)
+	if err != nil {
+		return err
+	}
 	if activationBlockNumber-l1BlockNumber > kpr.config.DKGStartBlockDelta {
 		log.Info().Interface("keyper-set", keyperSet).
 			Uint64("l1-block-number", l1BlockNumber).

--- a/rolling-shutter/medley/medley.go
+++ b/rolling-shutter/medley/medley.go
@@ -7,6 +7,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -199,4 +200,18 @@ func ShowHelpAndExit(cmd *cobra.Command, args []string) {
 	_ = args
 	_ = cmd.Help()
 	os.Exit(1)
+}
+
+func Uint64ToInt64Safe(u uint64) (int64, error) {
+	if u > math.MaxInt64 {
+		return math.MaxInt64, errors.New("int64 overflow")
+	}
+	return int64(u), nil
+}
+
+func Int64ToUint64Safe(i int64) (uint64, error) {
+	if i < 0 {
+		return 0, errors.New("uint64 can't be negative")
+	}
+	return uint64(i), nil
 }

--- a/rolling-shutter/snapshotkeyper/config.go
+++ b/rolling-shutter/snapshotkeyper/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	EncryptionKey            *ecies.PrivateKey
 	P2PKey                   p2pcrypto.PrivKey
 	DKGPhaseLength           uint64 // in shuttermint blocks
-	DKGStartBlockDelta       int64
+	DKGStartBlockDelta       uint64
 	ListenAddresses          []multiaddr.Multiaddr
 	CustomBootstrapAddresses []peer.AddrInfo
 	Environment              p2p.Environment

--- a/rolling-shutter/snapshotkeyper/snapshotkeyper.go
+++ b/rolling-shutter/snapshotkeyper/snapshotkeyper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/fx"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/kprapi"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/smobserver"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/eventsyncer"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/retry"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
@@ -232,7 +233,10 @@ func (snkpr *snapshotkeyper) handleOnChainKeyperSetChanges(ctx context.Context, 
 		return nil
 	}
 
-	activationBlockNumber := uint64(keyperSet.ActivationBlockNumber)
+	activationBlockNumber, err := medley.Int64ToUint64Safe(keyperSet.ActivationBlockNumber)
+	if err != nil {
+		return err
+	}
 	if activationBlockNumber-l1BlockNumber > snkpr.config.DKGStartBlockDelta {
 		log.Info().Interface("keyper-set", keyperSet).
 			Uint64("l1-block-number", l1BlockNumber).


### PR DESCRIPTION
The test `change-keyper-set` did only pass by accident because of the parameterization and the specific timeframe in which the keyper-set change is concluded compared to the program state.
The on-chain keyper set change in the test e.g. has the following parameters:

- activation-block-number: 24
- DKGStartBlockDelta: 1200
- last-seen block: 19
*Note that the last-seen-block represents the last l1 block that was communicated with the shuttermint chain,
and NOT the current l1 block-number retrieved by the l1 json rpc endpoint.*


This makes the check in handleOnChainKeyperSetChanges pass:

https://github.com/shutter-network/rolling-shutter/blob/34e728e6101dc8ffd87c54165c61793d3124541a/rolling-shutter/keyper/keyper.go#L238-L246

However if other values are chosen, the program will go into a livelock, because the last-seen block that 
makes the check pass, will never be updated again if no new batch-config becomes active:

- activation-block-number: 66
- DKGStartBlockDelta: 10
- last-seen block: 20

https://github.com/shutter-network/rolling-shutter/blob/34e728e6101dc8ffd87c54165c61793d3124541a/rolling-shutter/keyper/keyper.go#L184-L204

This creates a circular dependency of all keypers not being able to send out newly seen batch-configs and starting the DKG for them, and thus no batch config becoming active anytime soon, updating the last seen block.
This results in a livelock, where all new keyper-sets on l1 are ignored by the keypers.

```

2023/08/17 12:09:14.744049 INF [       keyper.go:166] handle on chain changes l1-block-number=207
2023/08/17 12:09:14.744846 INF [       keyper.go:257] not yet submitting config dkg-start-delta=10 keyper-set={"ActivationBlockNumber":66,"KeyperConfigIndex":1,"Keypers":["0x7D125eA18a7C56e8F5ab9834e8916E73A4Ae32F0","0x72318CFf1eC66D2F9f931090f2f9094930f60723","0x98B853d770b2F467B8e8AA6c06015Db12e973e94"],"Threshold":2} last-block-seen=20
```


One can see that the last block seen is stalling and thus way behind the current l1 block of 207 as well as behind the activation block number of the batch-config / keyper set change.
The config has not been sent out yet, and thus not voted upon and activated etc.

The fix for this issue is to not use the last seen block communicated to the tendermint chain in order to trigger sending out new batch configs, but use the current l1 block number locally seen by the keyper.