### PR TITLE
Fix config parsing defaults

### DIFF
--- a/rolling-shutter/collator/batcher/setup_test.go
+++ b/rolling-shutter/collator/batcher/setup_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/collator/config"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/db/cltrdb"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/configuration"
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/epoch"
+	enctime "github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/time"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/epochid"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/testdb"
 )
@@ -90,7 +90,7 @@ func newTestConfig(t *testing.T) *config.Config {
 	cfg := config.New()
 	err := configuration.SetExampleValuesRecursive(cfg)
 	assert.NilError(t, err)
-	cfg.EpochDuration = &epoch.Duration{Duration: 2 * time.Second}
+	cfg.EpochDuration = &enctime.Duration{Duration: 2 * time.Second}
 	return cfg
 }
 

--- a/rolling-shutter/collator/config/config.go
+++ b/rolling-shutter/collator/config/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/configuration"
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/epoch"
+	enctime "github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/time"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/p2p"
 )
 
@@ -20,6 +20,7 @@ func New() *Config {
 func (c *Config) Init() {
 	c.P2P = p2p.NewConfig()
 	c.Ethereum = configuration.NewEthnodeConfig()
+	c.EpochDuration = &enctime.Duration{}
 }
 
 type Config struct {
@@ -29,7 +30,7 @@ type Config struct {
 	HTTPListenAddress string
 
 	SequencerURL                 string
-	EpochDuration                *epoch.Duration
+	EpochDuration                *enctime.Duration
 	ExecutionBlockDelay          uint32
 	BatchIndexAcceptenceInterval uint32
 
@@ -46,7 +47,7 @@ func (c *Config) Name() string {
 }
 
 func (c *Config) SetDefaultValues() error {
-	c.EpochDuration = &epoch.Duration{
+	c.EpochDuration = &enctime.Duration{
 		Duration: time.Second * 5,
 	}
 	c.SequencerURL = "http://127.0.0.1:8555/"

--- a/rolling-shutter/collator/eonhandling_test.go
+++ b/rolling-shutter/collator/eonhandling_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/db/chainobsdb"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/db/cltrdb"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/configuration"
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/epoch"
+	enctime "github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/time"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/epochid"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/testdb"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/testkeygen"
@@ -29,7 +29,7 @@ func newTestConfig(t *testing.T) *config.Config {
 	cfg := config.New()
 	err := configuration.SetExampleValuesRecursive(cfg)
 	assert.NilError(t, err)
-	cfg.EpochDuration = &epoch.Duration{Duration: 1 * time.Second}
+	cfg.EpochDuration = &enctime.Duration{Duration: 1 * time.Second}
 	return cfg
 }
 

--- a/rolling-shutter/medley/configuration/command/parse.go
+++ b/rolling-shutter/medley/configuration/command/parse.go
@@ -87,9 +87,22 @@ func ParseCLI(v *viper.Viper, cmd *cobra.Command, config configuration.Config) e
 // have to be native types or implement the encoding.TextUnmarshaler
 // interface.
 func ParseViper(v *viper.Viper, config configuration.Config) error {
+	// This filtering is here because the AllKeys() also returns keys with value nil,
+	// although it doesn't say so in the docstring
+	keysSetByUser := []string{}
+	for _, k := range v.AllKeys() {
+		value := v.Get(k)
+		if value == nil {
+			// should not happen, since AllKeys() returns only keys holding a value,
+			// check just in case anything changes
+			continue
+		}
+		keysSetByUser = append(keysSetByUser, k)
+	}
+
 	// set the default values recursively for all configuration options
 	// the user did not provide by any means
-	err := configuration.SetDefaultValuesRecursive(config, v.AllKeys())
+	err := configuration.SetDefaultValuesRecursive(config, keysSetByUser)
 	if err != nil {
 		return err
 	}

--- a/rolling-shutter/medley/encodeable/time/duration.go
+++ b/rolling-shutter/medley/encodeable/time/duration.go
@@ -1,13 +1,13 @@
-package epoch
+package time
 
-import "time"
+import _time "time"
 
 type Duration struct {
-	time.Duration
+	_time.Duration
 }
 
 func (k *Duration) UnmarshalText(b []byte) error {
-	dur, err := time.ParseDuration(string(b))
+	dur, err := _time.ParseDuration(string(b))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The configuration parser did exclude the wrong set of configuration parameters during setting 
the default values. 
The cause for this was a bug / unexpected behaviour in `viper.AllKeys()` - the function returned also keys that had a nil value set internally. Those do not represent values that were set by the user, and thus should not be excluded from the default value override.