### PR TITLE
feat: add dump-config command

### DIFF
--- a/rolling-shutter/cmd/p2pnode/p2pnode.go
+++ b/rolling-shutter/cmd/p2pnode/p2pnode.go
@@ -22,6 +22,7 @@ func Cmd() *cobra.Command {
 			"",
 		),
 		command.WithGenerateConfigSubcommand(),
+		command.WithDumpConfigSubcommand(),
 	)
 	return builder.Command()
 }

--- a/rolling-shutter/cmd/snapshot/snapshot.go
+++ b/rolling-shutter/cmd/snapshot/snapshot.go
@@ -30,6 +30,7 @@ func Cmd() *cobra.Command {
 			"",
 		),
 		command.WithGenerateConfigSubcommand(),
+		command.WithDumpConfigSubcommand(),
 	)
 	builder.AddInitDBCommand(initDB)
 	return builder.Command()

--- a/rolling-shutter/cmd/snapshotkeyper/snapshotkeyper.go
+++ b/rolling-shutter/cmd/snapshotkeyper/snapshotkeyper.go
@@ -28,6 +28,7 @@ func Cmd() *cobra.Command {
 Shuttermint node which have to be started separately in advance.`,
 		),
 		command.WithGenerateConfigSubcommand(),
+		command.WithDumpConfigSubcommand(),
 	)
 	builder.AddInitDBCommand(initDB)
 	return builder.Command()

--- a/rolling-shutter/docs/rolling-shutter_p2pnode.md
+++ b/rolling-shutter/docs/rolling-shutter_p2pnode.md
@@ -24,5 +24,6 @@ rolling-shutter p2pnode [flags]
 ### SEE ALSO
 
 * [rolling-shutter](rolling-shutter.md)	 - A collection of commands to run and interact with Rolling Shutter nodes
+* [rolling-shutter p2pnode dump-config](rolling-shutter_p2pnode_dump-config.md)	 - Dump a 'p2pnode' configuration file, based on given config and env vars
 * [rolling-shutter p2pnode generate-config](rolling-shutter_p2pnode_generate-config.md)	 - Generate a 'p2pnode' configuration file
 

--- a/rolling-shutter/docs/rolling-shutter_p2pnode_dump-config.md
+++ b/rolling-shutter/docs/rolling-shutter_p2pnode_dump-config.md
@@ -1,0 +1,28 @@
+## rolling-shutter p2pnode dump-config
+
+Dump a 'p2pnode' configuration file, based on given config and env vars
+
+```
+rolling-shutter p2pnode dump-config [flags]
+```
+
+### Options
+
+```
+      --config string   config file
+  -h, --help            help for dump-config
+      --output string   output file
+```
+
+### Options inherited from parent commands
+
+```
+      --logformat string   set log format, possible values:  min, short, long, max (default "long")
+      --loglevel string    set log level, possible values:  warn, info, debug (default "info")
+      --no-color           do not write colored logs
+```
+
+### SEE ALSO
+
+* [rolling-shutter p2pnode](rolling-shutter_p2pnode.md)	 - Run a Shutter p2p bootstrap node
+

--- a/rolling-shutter/docs/rolling-shutter_snapshot.md
+++ b/rolling-shutter/docs/rolling-shutter_snapshot.md
@@ -24,6 +24,7 @@ rolling-shutter snapshot [flags]
 ### SEE ALSO
 
 * [rolling-shutter](rolling-shutter.md)	 - A collection of commands to run and interact with Rolling Shutter nodes
+* [rolling-shutter snapshot dump-config](rolling-shutter_snapshot_dump-config.md)	 - Dump a 'snapshot' configuration file, based on given config and env vars
 * [rolling-shutter snapshot generate-config](rolling-shutter_snapshot_generate-config.md)	 - Generate a 'snapshot' configuration file
 * [rolling-shutter snapshot initdb](rolling-shutter_snapshot_initdb.md)	 - Initialize the database of the 'snapshot'
 

--- a/rolling-shutter/docs/rolling-shutter_snapshot_dump-config.md
+++ b/rolling-shutter/docs/rolling-shutter_snapshot_dump-config.md
@@ -1,0 +1,28 @@
+## rolling-shutter snapshot dump-config
+
+Dump a 'snapshot' configuration file, based on given config and env vars
+
+```
+rolling-shutter snapshot dump-config [flags]
+```
+
+### Options
+
+```
+      --config string   config file
+  -h, --help            help for dump-config
+      --output string   output file
+```
+
+### Options inherited from parent commands
+
+```
+      --logformat string   set log format, possible values:  min, short, long, max (default "long")
+      --loglevel string    set log level, possible values:  warn, info, debug (default "info")
+      --no-color           do not write colored logs
+```
+
+### SEE ALSO
+
+* [rolling-shutter snapshot](rolling-shutter_snapshot.md)	 - Run the Snapshot Hub communication module
+

--- a/rolling-shutter/docs/rolling-shutter_snapshotkeyper.md
+++ b/rolling-shutter/docs/rolling-shutter_snapshotkeyper.md
@@ -29,6 +29,7 @@ rolling-shutter snapshotkeyper [flags]
 ### SEE ALSO
 
 * [rolling-shutter](rolling-shutter.md)	 - A collection of commands to run and interact with Rolling Shutter nodes
+* [rolling-shutter snapshotkeyper dump-config](rolling-shutter_snapshotkeyper_dump-config.md)	 - Dump a 'snapshotkeyper' configuration file, based on given config and env vars
 * [rolling-shutter snapshotkeyper generate-config](rolling-shutter_snapshotkeyper_generate-config.md)	 - Generate a 'snapshotkeyper' configuration file
 * [rolling-shutter snapshotkeyper initdb](rolling-shutter_snapshotkeyper_initdb.md)	 - Initialize the database of the 'snapshotkeyper'
 

--- a/rolling-shutter/docs/rolling-shutter_snapshotkeyper_dump-config.md
+++ b/rolling-shutter/docs/rolling-shutter_snapshotkeyper_dump-config.md
@@ -1,0 +1,28 @@
+## rolling-shutter snapshotkeyper dump-config
+
+Dump a 'snapshotkeyper' configuration file, based on given config and env vars
+
+```
+rolling-shutter snapshotkeyper dump-config [flags]
+```
+
+### Options
+
+```
+      --config string   config file
+  -h, --help            help for dump-config
+      --output string   output file
+```
+
+### Options inherited from parent commands
+
+```
+      --logformat string   set log format, possible values:  min, short, long, max (default "long")
+      --loglevel string    set log level, possible values:  warn, info, debug (default "info")
+      --no-color           do not write colored logs
+```
+
+### SEE ALSO
+
+* [rolling-shutter snapshotkeyper](rolling-shutter_snapshotkeyper.md)	 - Run a Shutter snapshotkeyper node
+

--- a/rolling-shutter/medley/configuration/command/options.go
+++ b/rolling-shutter/medley/configuration/command/options.go
@@ -29,6 +29,16 @@ func WithGenerateConfigSubcommand() Option {
 	}
 }
 
+// WithDumpConfigSubcommand attaches an additional subcommand
+// 'dump-config' to the command.
+// This allows to parse the given configuration (file, env-var),
+// and write out all accumulated values in a configuration file.
+func WithDumpConfigSubcommand() Option {
+	return func(c *commandBuilderConfig) {
+		c.dumpConfig = true
+	}
+}
+
 // WithFileSystem overwrites overwrite the `afero` Filesystem wrapper used
 // for reading and writing configuration files.
 // This is mainly helpful for tests, where an in-memory filesystem


### PR DESCRIPTION
This adds a command to parse the config paramters as usally (env-vars taking precedence over config-file taking precedence over default values), and write out the combined config as a toml config file.
This will not use the example and generated values from `generate-config` and needs required parameters to be set.