### PR TITLE
Chainobserver: sync from earliest contract deployment only

### DIFF
--- a/rolling-shutter/contract/deployment/deployment.go
+++ b/rolling-shutter/contract/deployment/deployment.go
@@ -118,11 +118,12 @@ func (c *Contracts) initKeypersConfigsList() error {
 	}
 	boundContract := bind.NewBoundContract(d.Address, d.ABI, c.Client, c.Client, c.Client)
 	c.KeypersConfigsListNewConfig = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "NewConfig",
-		Type:     reflect.TypeOf(contract.KeypersConfigsListNewConfig{}),
+		Contract:        boundContract,
+		Address:         d.Address,
+		FromBlockNumber: d.DeployBlockNumber,
+		ABI:             d.ABI,
+		Name:            "NewConfig",
+		Type:            reflect.TypeOf(contract.KeypersConfigsListNewConfig{}),
 	}
 	return nil
 }
@@ -139,11 +140,12 @@ func (c *Contracts) initCollatorConfigsList() error {
 	}
 	boundContract := bind.NewBoundContract(d.Address, d.ABI, c.Client, c.Client, c.Client)
 	c.CollatorConfigsListNewConfig = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "NewConfig",
-		Type:     reflect.TypeOf(contract.CollatorConfigsListNewConfig{}),
+		Contract:        boundContract,
+		FromBlockNumber: d.DeployBlockNumber,
+		Address:         d.Address,
+		ABI:             d.ABI,
+		Name:            "NewConfig",
+		Type:            reflect.TypeOf(contract.CollatorConfigsListNewConfig{}),
 	}
 	return nil
 }
@@ -160,25 +162,28 @@ func (c *Contracts) initKeypers() error {
 	}
 	boundContract := bind.NewBoundContract(d.Address, d.ABI, c.Client, c.Client, c.Client)
 	c.KeypersAdded = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "Added",
-		Type:     reflect.TypeOf(contract.AddrsSeqAdded{}),
+		FromBlockNumber: d.DeployBlockNumber,
+		Contract:        boundContract,
+		Address:         d.Address,
+		ABI:             d.ABI,
+		Name:            "Added",
+		Type:            reflect.TypeOf(contract.AddrsSeqAdded{}),
 	}
 	c.KeypersAppended = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "Appended",
-		Type:     reflect.TypeOf(contract.AddrsSeqAppended{}),
+		FromBlockNumber: d.DeployBlockNumber,
+		Contract:        boundContract,
+		Address:         d.Address,
+		ABI:             d.ABI,
+		Name:            "Appended",
+		Type:            reflect.TypeOf(contract.AddrsSeqAppended{}),
 	}
 	c.KeypersOwnershipTransferred = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "OwnershipTransferred",
-		Type:     reflect.TypeOf(contract.AddrsSeqOwnershipTransferred{}),
+		FromBlockNumber: d.DeployBlockNumber,
+		Contract:        boundContract,
+		Address:         d.Address,
+		ABI:             d.ABI,
+		Name:            "OwnershipTransferred",
+		Type:            reflect.TypeOf(contract.AddrsSeqOwnershipTransferred{}),
 	}
 	return nil
 }
@@ -195,25 +200,28 @@ func (c *Contracts) initCollator() error {
 	}
 	boundContract := bind.NewBoundContract(d.Address, d.ABI, c.Client, c.Client, c.Client)
 	c.CollatorsAdded = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "Added",
-		Type:     reflect.TypeOf(contract.AddrsSeqAdded{}),
+		FromBlockNumber: d.DeployBlockNumber,
+		Contract:        boundContract,
+		Address:         d.Address,
+		ABI:             d.ABI,
+		Name:            "Added",
+		Type:            reflect.TypeOf(contract.AddrsSeqAdded{}),
 	}
 	c.CollatorsAppended = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "Appended",
-		Type:     reflect.TypeOf(contract.AddrsSeqAppended{}),
+		FromBlockNumber: d.DeployBlockNumber,
+		Contract:        boundContract,
+		Address:         d.Address,
+		ABI:             d.ABI,
+		Name:            "Appended",
+		Type:            reflect.TypeOf(contract.AddrsSeqAppended{}),
 	}
 	c.CollatorsOwnershipTransferred = &eventsyncer.EventType{
-		Contract: boundContract,
-		Address:  d.Address,
-		ABI:      d.ABI,
-		Name:     "OwnershipTransferred",
-		Type:     reflect.TypeOf(contract.AddrsSeqOwnershipTransferred{}),
+		FromBlockNumber: d.DeployBlockNumber,
+		Contract:        boundContract,
+		Address:         d.Address,
+		ABI:             d.ABI,
+		Name:            "OwnershipTransferred",
+		Type:            reflect.TypeOf(contract.AddrsSeqOwnershipTransferred{}),
 	}
 	return nil
 }

--- a/rolling-shutter/medley/eventsyncer/eventsyncer.go
+++ b/rolling-shutter/medley/eventsyncer/eventsyncer.go
@@ -33,11 +33,12 @@ var (
 
 // EventType defines a single event type to filter for.
 type EventType struct {
-	Contract *bind.BoundContract
-	Address  common.Address
-	ABI      abi.ABI
-	Name     string
-	Type     reflect.Type
+	Contract        *bind.BoundContract
+	Address         common.Address
+	FromBlockNumber uint64
+	ABI             abi.ABI
+	Name            string
+	Type            reflect.Type
 }
 
 // logChannelItem is what is put on the (internal) channel of found logs. It can either contain a


### PR DESCRIPTION
Before we blindly synced blockchain events from the block 0 on without considering the contract creations.
Now, we take the minimum of all contract creation block-numbers for events we are interested in and start syncing there.
If we saved a sync progress later than that, this is used instead as the starting point for syncing.
