### PR TITLE
Graceful shutdown on service errors

### DIFF
--- a/rolling-shutter/chainobserver/observer.go
+++ b/rolling-shutter/chainobserver/observer.go
@@ -68,12 +68,17 @@ func (chainobs *ChainObserver) Observe(ctx context.Context, eventTypes []*events
 	})
 	errorgroup.Go(func() error {
 		for {
-			eventSyncUpdate, err := syncer.Next(errorctx)
-			if err != nil {
-				return err
-			}
-			if err := chainobs.handleEventSyncUpdate(errorctx, eventSyncUpdate); err != nil {
-				return err
+			select {
+			case <-errorctx.Done():
+				return errorctx.Err()
+			default:
+				eventSyncUpdate, err := syncer.Next(errorctx)
+				if err != nil {
+					return err
+				}
+				if err := chainobs.handleEventSyncUpdate(errorctx, eventSyncUpdate); err != nil {
+					return err
+				}
 			}
 		}
 	})

--- a/rolling-shutter/keyper/keyper.go
+++ b/rolling-shutter/keyper/keyper.go
@@ -119,7 +119,6 @@ func (kpr *keyper) Start(ctx context.Context, runner service.Runner) error {
 	if kpr.config.Metrics.Enabled {
 		epochkghandler.InitMetrics()
 		kpr.metricsServer = metricsserver.New(kpr.config.Metrics)
-		runner.Defer(kpr.metricsServer.Shutdown)
 	}
 
 	kpr.dbpool = dbpool

--- a/rolling-shutter/medley/metricsserver/metricsserver.go
+++ b/rolling-shutter/medley/metricsserver/metricsserver.go
@@ -22,7 +22,7 @@ func New(config *MetricsConfig) *MetricsServer {
 	return &MetricsServer{config: config, mux: http.NewServeMux()}
 }
 
-func (srv *MetricsServer) Start(_ context.Context, group service.Runner) error {
+func (srv *MetricsServer) Start(ctx context.Context, group service.Runner) error { //nolint:unparam
 	group.Go(func() error {
 		srv.mux.Handle("/metrics", promhttp.Handler())
 		addr := fmt.Sprintf("%s:%d", srv.config.Host, srv.config.Port)
@@ -38,6 +38,11 @@ func (srv *MetricsServer) Start(_ context.Context, group service.Runner) error {
 			return err
 		}
 		return nil
+	})
+	group.Go(func() error {
+		<-ctx.Done()
+		srv.Shutdown()
+		return ctx.Err()
 	})
 	return nil
 }

--- a/rolling-shutter/medley/rootcmd/root.go
+++ b/rolling-shutter/medley/rootcmd/root.go
@@ -162,10 +162,9 @@ func Cmd() *cobra.Command {
 
 func Main(c *cobra.Command) {
 	status := 0
-
 	if err := c.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		status = 1
 	}
-
 	os.Exit(status)
 }

--- a/rolling-shutter/snapshot/snapshot.go
+++ b/rolling-shutter/snapshot/snapshot.go
@@ -91,8 +91,6 @@ func (snp *Snapshot) Start(ctx context.Context, runner service.Runner) error {
 	hub := hubapi.New(snp.Config.SnapshotHubURL)
 	snp.hubapi = hub
 
-	runner.Defer(snp.jrpc.Shutdown)
-
 	snp.setupP2PHandler()
 	return runner.StartService(snp.getServices()...)
 }

--- a/rolling-shutter/snapshot/snapshot.go
+++ b/rolling-shutter/snapshot/snapshot.go
@@ -86,7 +86,6 @@ func (snp *Snapshot) Start(ctx context.Context, runner service.Runner) error {
 			return err
 		}
 		snp.metricsServer = metricsserver.New(snp.Config.Metrics)
-		runner.Defer(snp.metricsServer.Shutdown)
 	}
 
 	hub := hubapi.New(snp.Config.SnapshotHubURL)

--- a/rolling-shutter/snapshot/snpjrpc/server.go
+++ b/rolling-shutter/snapshot/snpjrpc/server.go
@@ -145,7 +145,7 @@ func New(
 	return &jrpc
 }
 
-func (snpjrpc *SnpJRPC) Start(_ context.Context, group service.Runner) error {
+func (snpjrpc *SnpJRPC) Start(ctx context.Context, group service.Runner) error { //nolint:unparam
 	group.Go(func() error {
 		httpServer := snpjrpc.Server.Prepare()
 		log.Info().Str("address", snpjrpc.Server.Host).Msg("Running JSON-RPC server at")
@@ -153,6 +153,11 @@ func (snpjrpc *SnpJRPC) Start(_ context.Context, group service.Runner) error {
 			return err
 		}
 		return nil
+	})
+	group.Go(func() error {
+		<-ctx.Done()
+		snpjrpc.Shutdown()
+		return ctx.Err()
 	})
 	return nil
 }

--- a/rolling-shutter/snapshotkeyper/snapshotkeyper.go
+++ b/rolling-shutter/snapshotkeyper/snapshotkeyper.go
@@ -90,7 +90,6 @@ func (snkpr *snapshotkeyper) Start(ctx context.Context, runner service.Runner) e
 	if snkpr.config.Metrics.Enabled {
 		epochkghandler.InitMetrics()
 		snkpr.metricsServer = metricsserver.New(snkpr.config.Metrics)
-		runner.Defer(snkpr.metricsServer.Shutdown)
 	}
 
 	snkpr.dbpool = dbpool


### PR DESCRIPTION
Before, we omitted polling for upstream context `ctx.Done()` sends in some services.
The errorgroup of the overall service will send ctx.Done() whenever there is an error in the spawned routines.
However all other routines have to manually make sure they react on this signal.

Now, all goroutines spawned from services implement this graceful shutdown.
In some implementations, there is quite some async / long running code between checks for new context signals.
This could be optimised in the future.

The correct shutdown of all goroutines has the effect that the error that caused that shutdown will now bubble up until the main invocation of the command.
The resulting error is now printed to stderr.