### PR TITLE
Redact sensitive values on config logging

### DIFF
--- a/rolling-shutter/keyper/config.go
+++ b/rolling-shutter/keyper/config.go
@@ -110,7 +110,7 @@ func NewShuttermintConfig() *ShuttermintConfig {
 type ShuttermintConfig struct {
 	ShuttermintURL     string
 	ValidatorPublicKey *keys.Ed25519Public `shconfig:",required"`
-	EncryptionKey      *keys.ECDSAPrivate  `shconfig:",required"`
+	EncryptionKey      *keys.ECDSAPrivate  `shconfig:",required,sensitive"`
 	DKGPhaseLength     int64               // in shuttermint blocks
 	DKGStartBlockDelta uint64
 }

--- a/rolling-shutter/medley/configuration/command/command.go
+++ b/rolling-shutter/medley/configuration/command/command.go
@@ -92,9 +92,11 @@ func Build[T configuration.Config](
 			if err != nil {
 				return errors.Wrap(err, "unable to parse configuration")
 			}
-			log.Debug().
-				Interface("config", cfg).
-				Msg("got config")
+			err = LogConfig(log.Debug(), cfg, "using configuration")
+			// XXX should the program panic when the config can't be logged?
+			if err != nil {
+				return err
+			}
 			return main(cfg)
 		},
 	}

--- a/rolling-shutter/medley/configuration/command/parse.go
+++ b/rolling-shutter/medley/configuration/command/parse.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -135,4 +136,18 @@ func ParseViper(v *viper.Viper, config configuration.Config) error {
 		return err
 	}
 	return config.Validate()
+}
+
+func LogConfig(ev *zerolog.Event, config configuration.Config, msg string) error {
+	s := configuration.GetSensitiveRecursive(config)
+	redactedPaths := []string{}
+	for redacted := range s {
+		redactedPaths = append(redactedPaths, redacted)
+	}
+	dc, err := configuration.ToDict(config, redactedPaths)
+	if err != nil {
+		return err
+	}
+	ev.Interface("config", dc).Msg(msg)
+	return nil
 }

--- a/rolling-shutter/medley/configuration/ethereum.go
+++ b/rolling-shutter/medley/configuration/ethereum.go
@@ -17,7 +17,7 @@ func NewEthnodeConfig() *EthnodeConfig {
 }
 
 type EthnodeConfig struct {
-	PrivateKey    *keys.ECDSAPrivate `shconfig:",required"`
+	PrivateKey    *keys.ECDSAPrivate `shconfig:",required,sensitive"`
 	ContractsURL  string             `                     comment:"The JSON RPC endpoint where the contracts are accessible"`
 	DeploymentDir string             `                     comment:"Contract source directory"`
 	EthereumURL   string             `                     comment:"The layer 1 JSON RPC endpoint"`

--- a/rolling-shutter/medley/decodehooks.go
+++ b/rolling-shutter/medley/decodehooks.go
@@ -58,7 +58,7 @@ func TextMarshalerHook(from reflect.Value, to reflect.Value) (interface{}, error
 	return string(mshl), nil
 }
 
-func mapstructureDecode(input, result any, hookFunc mapstructure.DecodeHookFunc) error {
+func MapstructureDecode(input, result any, hookFunc mapstructure.DecodeHookFunc) error {
 	decoder, err := mapstructure.NewDecoder(
 		&mapstructure.DecoderConfig{
 			Result:     result,
@@ -71,7 +71,7 @@ func mapstructureDecode(input, result any, hookFunc mapstructure.DecodeHookFunc)
 }
 
 func MapstructureMarshal(input, result any) error {
-	return mapstructureDecode(
+	return MapstructureDecode(
 		input,
 		result,
 		mapstructure.ComposeDecodeHookFunc(
@@ -81,7 +81,7 @@ func MapstructureMarshal(input, result any) error {
 }
 
 func MapstructureUnmarshal(input, result any) error {
-	return mapstructureDecode(
+	return MapstructureDecode(
 		input,
 		result,
 		mapstructure.ComposeDecodeHookFunc(

--- a/rolling-shutter/p2p/config.go
+++ b/rolling-shutter/p2p/config.go
@@ -41,7 +41,7 @@ func (c *Config) Init() {
 }
 
 type Config struct {
-	P2PKey                   *keys.Libp2pPrivate `shconfig:",required"`
+	P2PKey                   *keys.Libp2pPrivate `shconfig:",required,sensitive"`
 	ListenAddresses          []*address.P2PAddress
 	CustomBootstrapAddresses []*address.P2PAddress `comment:"Overwrite p2p boostrap nodes"`
 	Environment              env.Environment


### PR DESCRIPTION
This introduces another `shconfig` tag `sensitive`.
When using the `LogConfig` function, all values tagged with sensitive will be redacted upon logging and a `(sensitive)` value will be shown instead.
The tree-traversal based dict-parsing function might not be the most efficient, but logging of the config values is expected to be done infrequently / once only. 