### PR TITLE
fix: allow bootstrap node to have no bootstrap peers

### DIFF
--- a/play/bb.edn
+++ b/play/bb.edn
@@ -36,7 +36,7 @@
       (Long/valueOf (or (System/getenv s) default)))
 
     (def num-keypers (long-from-env "PLAY_NUM_KEYPERS" "3"))
-    (def num-bootstrappers 1)
+    (def num-bootstrappers (long-from-env "PLAY_NUM_BOOTSTRAPPERS" "1"))
 
     (def windows? (babashka.core/windows?))
     (def no-color? windows?)

--- a/rolling-shutter/p2p/handler.go
+++ b/rolling-shutter/p2p/handler.go
@@ -84,7 +84,7 @@ func New(config *Config) (*P2PHandler, error) {
 			cfg.BootstrapPeers = append(cfg.BootstrapPeers, *ai)
 		}
 	}
-	if len(cfg.BootstrapPeers) < 1 {
+	if len(cfg.BootstrapPeers) < 1 && !cfg.IsBootstrapNode {
 		return nil, errors.New("no bootstrap peers configured")
 	}
 


### PR DESCRIPTION
Starting a local `p2pnode` with the default *play* setup revealed that a bootstrap node was required to 
have at least one other bootstrap node configured:

```
2023/09/26 12:43:49.853125 INF [       p2pnode.go:33] starting p2pnode version="(devel-a9428214fe9b115b5ebbce6ae5e7f3be1ce75f9f) (go1.20.3, darwin-arm64)"
Error: failed to instantiate p2pnode: no bootstrap peers configured
failed to instantiate p2pnode: no bootstrap peers configured
Error: rolling-shutter returned with non-zero exit code 1
```
This is because due to the hardcoded number of 1 bootstrap node in the generated *play* config,
the sole bootstrapper has no other bootstrap node configures.


While it makes sense to require at least 1 bootstrap node configured for a peer, the p2p network should be
be bootstrapped by only one bootstrap node.

Additionally, the previously hardcoded number of bootstrappers is now exposed via the `PLAY_NUM_BOOTSRAPPERS` env-var and still defaults to 1.