### PR TITLE
typo in error message when decoding epochID

### DIFF
--- a/rolling-shutter/shcryptowasm/shutter_crypto_wasm.go
+++ b/rolling-shutter/shcryptowasm/shutter_crypto_wasm.go
@@ -147,8 +147,8 @@ func decodeEpochIDArgBytes(arg js.Value) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(b) != 32 {
-		return nil, fmt.Errorf("sigma must be 32 bytes, got %d", len(b))
+	if len(b) != shcrypto.BlockSize {
+		return nil, fmt.Errorf("epochID must be %d bytes, got %d", shcrypto.BlockSize, len(b))
 	}
 	return b, nil
 }


### PR DESCRIPTION
A copypasta small typo.

Background story: while trying to use shutter crypto wasm in a node application to encrypt transactions with the very unique BN256 key pairings, I kept getting errors while encrypting regarding the length of the byte array of sigma. However it was the epochID that needs to be of BlockSize. 

Here is a small contribution to help others not pull their hair out while debugging :)