### PR TITLE
Fix bb peer command and bootstrap node peering

### DIFF
--- a/play/README.md
+++ b/play/README.md
@@ -118,6 +118,12 @@ process-compose -t=false up & # to start postgres
 bb test-system
 ```
 
+Keep in mind that the configurations are generated within the container on first
+invocation. This means that things like private keys and peer addresses are
+changing when the container is started with the `docker run --rm` command. To
+keep those values persistent, either the configuration files have to be copied
+to the container, or the container should be reused throughout runs.
+
 ### Self contained testrunner
 
 It is possible to compile the testrunner into a self contained `.jar` file, by

--- a/play/bb.edn
+++ b/play/bb.edn
@@ -377,9 +377,7 @@
                bootstr-cfgs (get cfgs-by-is-btsrp true)
                non-bootstr-cfgs (get cfgs-by-is-btsrp false)
                peers (flatten (map (fn [cfg] (get cfg :ext-addrs)) bootstr-cfgs))]
-           (doseq [cfg bootstr-cfgs]
-             (toml-edit-file (get cfg :cfg-file) {"CustomBootstrapAddresses" []}))
-           (doseq [cfg non-bootstr-cfgs]
+           (doseq [cfg cfgs]
              (toml-edit-file (get cfg :cfg-file) {"CustomBootstrapAddresses" peers})))}
 
   init:testchain

--- a/rolling-shutter/p2p/bootstrap.go
+++ b/rolling-shutter/p2p/bootstrap.go
@@ -79,18 +79,20 @@ func bootstrap(
 	}
 
 	if config.IsBootstrapNode {
-		// A bootstrap node is not required to connect to other bootstrap nodes.
-		// If however we did configure a list of bootstrap nodes,
-		// we should try a long time to connect to at least one other bootstrapper first.
-		_, err := retry.FunctionCall(
-			ctx,
-			f,
-			retry.MaxInterval(5*time.Hour),
-			retry.StopOnErrors(errInsufficientBootstrpConfigured),
-			retry.Interval(2*time.Minute))
-		if err != nil {
-			log.Error().Err(err).
-				Msg("failed to bootstrap, continuing without peer connections.")
+		if len(config.BootstrapPeers) > 0 {
+			// A bootstrap node is not required to connect to other bootstrap nodes.
+			// If however we did configure a list of bootstrap nodes,
+			// we should try a long time to connect to at least one other bootstrapper first.
+			_, err := retry.FunctionCall(
+				ctx,
+				f,
+				retry.MaxInterval(5*time.Hour),
+				retry.StopOnErrors(errInsufficientBootstrpConfigured),
+				retry.Interval(2*time.Minute))
+			if err != nil {
+				log.Error().Err(err).
+					Msg("failed to bootstrap, continuing without peer connections.")
+			}
 		}
 	} else {
 		_, err := retry.FunctionCall(


### PR DESCRIPTION
The bootstrap nodes will filter out their address from the list of bootstrap nodes.
When no bootstrap nodes are configured, an error will be raised.

For this the 'peer' command in the bb scripts should not edit the config files of bootstrap nodes differently than
non-bootstrap nodes.

Additionally, a bootstrap node will not error on an empty `config.BootstrapPeers` configuration.