### PR TITLE
Fix misleading field naming

### DIFF
--- a/rolling-shutter/go.sum
+++ b/rolling-shutter/go.sum
@@ -830,8 +830,6 @@ github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYED
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/shutter-network/shop-contracts v0.0.0-20231220085304-80b8977d0bca h1:05Ghqw3FqH/UFuYIzc7z6GJyHk3HxAqY3iuY4L3x4Ow=
 github.com/shutter-network/shop-contracts v0.0.0-20231220085304-80b8977d0bca/go.mod h1:LEWXLRruvxq9fe2oKtJI3xfzbauhfWTjOczHN61RU+4=
-github.com/shutter-network/shutter/shlib v0.1.13 h1:9YloDJBdhFAKm2GMg4gBNeaJ+Mw9Qzeh5Kz9A2ayp1E=
-github.com/shutter-network/shutter/shlib v0.1.13/go.mod h1:RlYNZjx+pfKAi0arH+jfdlxG4kQ75UFzDfVjgCVYaUw=
 github.com/shutter-network/shutter/shlib v0.1.15 h1:HsAL3h5govZjFcHaox2Nf1DxawCjTcR0qNb+08YaM5c=
 github.com/shutter-network/shutter/shlib v0.1.15/go.mod h1:RlYNZjx+pfKAi0arH+jfdlxG4kQ75UFzDfVjgCVYaUw=
 github.com/shutter-network/txtypes v0.1.0 h1:QqdiiiB9AiBCSJ/ke6z1ZoDGfu2+1Lgpz5vHzVN4FKc=

--- a/rolling-shutter/keyperimpl/optimism/bootstrap/bootstrap.go
+++ b/rolling-shutter/keyperimpl/optimism/bootstrap/bootstrap.go
@@ -38,7 +38,7 @@ func BootstrapValidators(config *Config) error {
 		ks.ActivationBlock,
 		ks.Members,
 		ks.Threshold,
-		ks.Eon,
+		ks.Index,
 	)
 
 	err = ms.SendMessage(ctx, batchConfigMsg)

--- a/rolling-shutter/keyperimpl/optimism/keyper.go
+++ b/rolling-shutter/keyperimpl/optimism/keyper.go
@@ -114,12 +114,12 @@ func (kpr *Keyper) newBlock(_ context.Context, ev *syncevent.LatestBlock) error 
 func (kpr *Keyper) newKeyperSet(ctx context.Context, ev *syncevent.KeyperSet) error {
 	log.Info().
 		Uint64("activation-block", ev.ActivationBlock).
-		Uint64("eon", ev.Eon).
+		Uint64("index", ev.Index).
 		Msg("new keyper set added")
 	return kpr.dbpool.BeginFunc(ctx, func(tx pgx.Tx) error {
 		obskeyperdb := obskeyper.New(tx)
 
-		keyperConfigIndex, err := medley.Uint64ToInt64Safe(ev.Eon)
+		keyperConfigIndex, err := medley.Uint64ToInt64Safe(ev.Index)
 		if err != nil {
 			return errors.Wrap(err, ErrParseKeyperSet.Error())
 		}

--- a/rolling-shutter/medley/chainsync/event/events.go
+++ b/rolling-shutter/medley/chainsync/event/events.go
@@ -11,7 +11,7 @@ type (
 		ActivationBlock uint64
 		Members         []common.Address
 		Threshold       uint64
-		Eon             uint64
+		Index           uint64
 
 		AtBlockNumber *number.BlockNumber `json:",omitempty"`
 	}

--- a/rolling-shutter/medley/chainsync/syncer/keyperset.go
+++ b/rolling-shutter/medley/chainsync/syncer/keyperset.go
@@ -151,7 +151,7 @@ func (s *KeyperSetSyncer) getInitialKeyperSets(ctx context.Context) ([]*event.Ke
 		return nil, err
 	}
 
-	for i := ks.Eon + 1; i < numKS; i++ {
+	for i := ks.Index + 1; i < numKS; i++ {
 		ks, err = s.GetKeyperSetByIndex(ctx, opts, i)
 		if err != nil {
 			return nil, err
@@ -237,7 +237,7 @@ func (s *KeyperSetSyncer) newEvent(
 	if err != nil {
 		return nil, makeCallError("Threshold", err)
 	}
-	eon, err := s.Contract.GetKeyperSetIndexByBlock(opts, activationBlock)
+	keyperSetIndex, err := s.Contract.GetKeyperSetIndexByBlock(opts, activationBlock)
 	if err != nil {
 		return nil, makeCallError("KeyperSetIndexByBlock", err)
 	}
@@ -245,8 +245,9 @@ func (s *KeyperSetSyncer) newEvent(
 		ActivationBlock: activationBlock,
 		Members:         members,
 		Threshold:       threshold,
-		Eon:             eon,
-		AtBlockNumber:   number.BigToBlockNumber(opts.BlockNumber),
+		Index:           keyperSetIndex,
+
+		AtBlockNumber: number.BigToBlockNumber(opts.BlockNumber),
 	}, nil
 }
 


### PR DESCRIPTION
This was meant as a start to fix #434. However, I did not manage to reproduce the bug. This PR only renames the `Eon` field to `Index` in the `KeyperSet` struct of the `chainsync/event` package.