### PR TITLE
feat: consider reorgs in chainsync

### DIFF
--- a/rolling-shutter/go.sum
+++ b/rolling-shutter/go.sum
@@ -830,8 +830,6 @@ github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYED
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/shutter-network/shop-contracts v0.0.0-20231220085304-80b8977d0bca h1:05Ghqw3FqH/UFuYIzc7z6GJyHk3HxAqY3iuY4L3x4Ow=
 github.com/shutter-network/shop-contracts v0.0.0-20231220085304-80b8977d0bca/go.mod h1:LEWXLRruvxq9fe2oKtJI3xfzbauhfWTjOczHN61RU+4=
-github.com/shutter-network/shutter/shlib v0.1.13 h1:9YloDJBdhFAKm2GMg4gBNeaJ+Mw9Qzeh5Kz9A2ayp1E=
-github.com/shutter-network/shutter/shlib v0.1.13/go.mod h1:RlYNZjx+pfKAi0arH+jfdlxG4kQ75UFzDfVjgCVYaUw=
 github.com/shutter-network/shutter/shlib v0.1.15 h1:HsAL3h5govZjFcHaox2Nf1DxawCjTcR0qNb+08YaM5c=
 github.com/shutter-network/shutter/shlib v0.1.15/go.mod h1:RlYNZjx+pfKAi0arH+jfdlxG4kQ75UFzDfVjgCVYaUw=
 github.com/shutter-network/txtypes v0.1.0 h1:QqdiiiB9AiBCSJ/ke6z1ZoDGfu2+1Lgpz5vHzVN4FKc=

--- a/rolling-shutter/medley/chainsync/options.go
+++ b/rolling-shutter/medley/chainsync/options.go
@@ -39,15 +39,80 @@ type options struct {
 
 func (o *options) verify() error {
 	if o.clientURL != "" && o.ethClient != nil {
-		// TODO: error message
-		return errors.New("can't use client and client url")
+		return errors.New("'WithClient' and 'WithClientURL' options are mutually exclusive")
 	}
 	if o.clientURL == "" && o.ethClient == nil {
-		// TODO: error message
-		return errors.New("have to provide either url or client")
+		return errors.New("either 'WithClient' or 'WithClientURL' options are expected")
 	}
 	// TODO: check for the existence of the contract addresses depending on
 	// what handlers are not nil
+	return nil
+}
+
+func (o *options) applyHandler(c *Client) error {
+	var err error
+	syncedServices := []syncer.ManualFilterHandler{}
+
+	c.KeyperSetManager, err = bindings.NewKeyperSetManager(*o.keyperSetManagerAddress, o.ethClient)
+	if err != nil {
+		return err
+	}
+	c.kssync = &syncer.KeyperSetSyncer{
+		Client:   o.ethClient,
+		Contract: c.KeyperSetManager,
+		Log:      c.log,
+		Handler:  o.handlerKeyperSet,
+	}
+	if o.handlerKeyperSet != nil {
+		syncedServices = append(syncedServices, c.kssync)
+	}
+
+	c.KeyBroadcast, err = bindings.NewKeyBroadcastContract(*o.keyBroadcastContractAddress, o.ethClient)
+	if err != nil {
+		return err
+	}
+	c.epksync = &syncer.EonPubKeySyncer{
+		Client:           o.ethClient,
+		Log:              c.log,
+		KeyBroadcast:     c.KeyBroadcast,
+		KeyperSetManager: c.KeyperSetManager,
+		Handler:          o.handlerEonPublicKey,
+	}
+	if o.handlerEonPublicKey != nil {
+		syncedServices = append(syncedServices, c.epksync)
+	}
+	c.sssync = &syncer.ShutterStateSyncer{
+		Client:   o.ethClient,
+		Contract: c.KeyperSetManager,
+		Log:      c.log,
+		Handler:  o.handlerShutterState,
+	}
+	if o.handlerShutterState != nil {
+		syncedServices = append(syncedServices, c.sssync)
+	}
+
+	if o.handlerBlock == nil {
+		// Even if the user is not interested in handling new block events,
+		// the streaming block handler must be running in order to
+		// synchronize polling of new contract events.
+		// Since the handler function is always called, we need to
+		// inject a noop-handler
+		o.handlerBlock = func(ctx context.Context, lb *event.LatestBlock) error {
+			return nil
+		}
+	}
+
+	c.uhsync = &syncer.UnsafeHeadSyncer{
+		Client:             o.ethClient,
+		Log:                c.log,
+		Handler:            o.handlerBlock,
+		SyncedHandler:      syncedServices,
+		FetchActiveAtStart: o.fetchActivesAtSyncStart,
+		SyncStartBlock:     o.syncStart,
+	}
+	if o.handlerBlock != nil {
+		c.services = append(c.services, c.uhsync)
+	}
 	return nil
 }
 
@@ -67,16 +132,8 @@ func (o *options) apply(ctx context.Context, c *Client) error {
 		}
 	}
 	client = o.ethClient
-
 	c.EthereumClient = client
 
-	if o.logger != nil {
-		c.log = o.logger
-		// NOCHECKIN:
-		c.log.Info("got logger in options")
-	}
-
-	syncedServices := []syncer.ManualFilterHandler{}
 	// the nil passthrough will use "latest" for each call,
 	// but we want to harmonize and fix the sync start to a specific block.
 	if o.syncStart.IsLatest() {
@@ -87,82 +144,12 @@ func (o *options) apply(ctx context.Context, c *Client) error {
 		o.syncStart = number.NewBlockNumber(&latestBlock)
 	}
 
-	c.KeyperSetManager, err = bindings.NewKeyperSetManager(*o.keyperSetManagerAddress, client)
-	if err != nil {
-		return err
-	}
-	c.kssync = &syncer.KeyperSetSyncer{
-		Client:                  client,
-		Contract:                c.KeyperSetManager,
-		Log:                     c.log,
-		StartBlock:              o.syncStart,
-		Handler:                 o.handlerKeyperSet,
-		FetchActiveAtStartBlock: o.fetchActivesAtSyncStart,
-		DisableEventWatcher:     true,
-	}
-	if o.handlerKeyperSet != nil {
-		c.services = append(c.services, c.kssync)
-		syncedServices = append(syncedServices, c.kssync)
+	if o.logger != nil {
+		c.log = o.logger
 	}
 
-	c.KeyBroadcast, err = bindings.NewKeyBroadcastContract(*o.keyBroadcastContractAddress, client)
-	if err != nil {
-		return err
-	}
-	c.epksync = &syncer.EonPubKeySyncer{
-		Client:                  client,
-		Log:                     c.log,
-		KeyBroadcast:            c.KeyBroadcast,
-		KeyperSetManager:        c.KeyperSetManager,
-		Handler:                 o.handlerEonPublicKey,
-		StartBlock:              o.syncStart,
-		FetchActiveAtStartBlock: o.fetchActivesAtSyncStart,
-		DisableEventWatcher:     true,
-	}
-	if o.handlerEonPublicKey != nil {
-		c.services = append(c.services, c.epksync)
-		syncedServices = append(syncedServices, c.epksync)
-	}
-
-	c.sssync = &syncer.ShutterStateSyncer{
-		Client:                  client,
-		Contract:                c.KeyperSetManager,
-		Log:                     c.log,
-		Handler:                 o.handlerShutterState,
-		StartBlock:              o.syncStart,
-		FetchActiveAtStartBlock: o.fetchActivesAtSyncStart,
-		DisableEventWatcher:     true,
-	}
-	if o.handlerShutterState != nil {
-		c.services = append(c.services, c.sssync)
-		syncedServices = append(syncedServices, c.sssync)
-	}
-
-	if o.handlerBlock == nil {
-		// NOOP - but we need to run the UnsafeHeadSyncer.
-		// This is to keep the inner workings consisten,
-		// we use the DisableEventWatcher mechanism in combination
-		// with the UnsafeHeadSyncer instead of the streaming
-		// Watch... subscription on events.
-		// TODO: think about allowing the streaming events,
-		// when guaranteed event order (event1,event2,new-block-event)
-		// is not required
-		o.handlerBlock = func(ctx context.Context, lb *event.LatestBlock) error {
-			return nil
-		}
-	}
-
-	c.uhsync = &syncer.UnsafeHeadSyncer{
-		Client:        client,
-		Log:           c.log,
-		Handler:       o.handlerBlock,
-		SyncedHandler: syncedServices,
-	}
-	if o.handlerBlock != nil {
-		c.services = append(c.services, c.uhsync)
-	}
 	c.privKey = o.privKey
-	return nil
+	return o.applyHandler(c)
 }
 
 func defaultOptions() *options {

--- a/rolling-shutter/medley/chainsync/syncer/keyperset.go
+++ b/rolling-shutter/medley/chainsync/syncer/keyperset.go
@@ -12,7 +12,6 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/client"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/event"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/number"
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
 )
 
 func makeCallError(attrName string, err error) error {
@@ -24,114 +23,67 @@ const channelSize = 10
 var _ ManualFilterHandler = &KeyperSetSyncer{}
 
 type KeyperSetSyncer struct {
-	Client     client.EthereumClient
-	Contract   *bindings.KeyperSetManager
-	Log        log.Logger
-	StartBlock *number.BlockNumber
-	Handler    event.KeyperSetHandler
-	// disable this when the QueryAndHandle manual polling should be used:
-	FetchActiveAtStartBlock bool
-	DisableEventWatcher     bool
-
-	keyperAddedCh chan *bindings.KeyperSetManagerKeyperSetAdded
+	Client   client.EthereumClient
+	Contract *bindings.KeyperSetManager
+	Log      log.Logger
+	Handler  event.KeyperSetHandler
 }
 
 func (s *KeyperSetSyncer) QueryAndHandle(ctx context.Context, block uint64) error {
 	opts := &bind.FilterOpts{
-		// FIXME: does this work, or do we need index -1 or something?
 		Start:   block,
 		End:     &block,
 		Context: ctx,
 	}
 	iter, err := s.Contract.FilterKeyperSetAdded(opts)
-	// TODO: what errors possible?
 	if err != nil {
 		return err
 	}
 	defer iter.Close()
 
 	for iter.Next() {
-		select {
-		// XXX: this can be nil during the handlers startup.
-		// As far as I understand, a nil channel is never selected.
-		// Will it be selected as soon as the channel is not nil anymore?
-		case s.keyperAddedCh <- iter.Event:
-		case <-ctx.Done():
-			return ctx.Err()
+		err := s.handle(ctx, iter.Event)
+		if err != nil {
+			s.Log.Error(
+				"handler for `NewKeyperSet` errored",
+				"error",
+				err.Error(),
+			)
 		}
 	}
-	// XXX: it looks like this is nil when the iterator is
-	// exhausted without failures
 	if err := iter.Error(); err != nil {
 		return errors.Wrap(err, "filter iterator error")
 	}
 	return nil
 }
 
-func (s *KeyperSetSyncer) Start(ctx context.Context, runner service.Runner) error {
-	if s.Handler == nil {
-		return errors.New("no handler registered")
+func (s *KeyperSetSyncer) HandleVirtualEvent(ctx context.Context, block *number.BlockNumber) error {
+	initial, err := s.getInitialKeyperSets(ctx, block)
+	if err != nil {
+		return err
 	}
-
-	// the latest block still has to be fixed.
-	// otherwise we could skip some block events
-	// between the initial poll and the subscription.
-	if s.StartBlock.IsLatest() {
-		latest, err := s.Client.BlockNumber(ctx)
+	for _, ks := range initial {
+		err = s.Handler(ctx, ks)
 		if err != nil {
-			return err
-		}
-		s.StartBlock.SetUint64(latest)
-	}
-
-	watchOpts := &bind.WatchOpts{
-		Start:   s.StartBlock.ToUInt64Ptr(),
-		Context: ctx,
-	}
-
-	if s.FetchActiveAtStartBlock {
-		initial, err := s.getInitialKeyperSets(ctx)
-		if err != nil {
-			return err
-		}
-		for _, ks := range initial {
-			err = s.Handler(ctx, ks)
-			if err != nil {
-				s.Log.Error(
-					"handler for `NewKeyperSet` errored for initial sync",
-					"error",
-					err.Error(),
-				)
-			}
+			s.Log.Error(
+				"handler for `NewKeyperSet` errored for initial sync",
+				"error",
+				err.Error(),
+			)
 		}
 	}
-	s.keyperAddedCh = make(chan *bindings.KeyperSetManagerKeyperSetAdded, channelSize)
-	runner.Defer(func() {
-		close(s.keyperAddedCh)
-	})
-	if !s.DisableEventWatcher {
-		subs, err := s.Contract.WatchKeyperSetAdded(watchOpts, s.keyperAddedCh)
-		// FIXME: what to do on subs.Error()
-		if err != nil {
-			return err
-		}
-		runner.Defer(subs.Unsubscribe)
-	}
-	runner.Go(func() error {
-		return s.watchNewKeypersService(ctx)
-	})
 	return nil
 }
 
-func (s *KeyperSetSyncer) getInitialKeyperSets(ctx context.Context) ([]*event.KeyperSet, error) {
+func (s *KeyperSetSyncer) getInitialKeyperSets(ctx context.Context, block *number.BlockNumber) ([]*event.KeyperSet, error) {
 	opts := &bind.CallOpts{
 		Context:     ctx,
-		BlockNumber: s.StartBlock.Int,
+		BlockNumber: block.Int,
 	}
 	if err := guardCallOpts(opts, false); err != nil {
 		return nil, err
 	}
-	bn := s.StartBlock.ToUInt64Ptr()
+	bn := block.ToUInt64Ptr()
 	if bn == nil {
 		// this should not be the case
 		return nil, errors.New("start block is 'latest'")
@@ -140,7 +92,7 @@ func (s *KeyperSetSyncer) getInitialKeyperSets(ctx context.Context) ([]*event.Ke
 	initialKeyperSets := []*event.KeyperSet{}
 	// this blocknumber specifies the argument to the contract
 	// getter
-	ks, err := s.GetKeyperSetForBlock(ctx, opts, s.StartBlock)
+	ks, err := s.GetKeyperSetForBlock(ctx, opts, block)
 	if err != nil {
 		return nil, err
 	}
@@ -250,38 +202,20 @@ func (s *KeyperSetSyncer) newEvent(
 	}, nil
 }
 
-func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context) error {
-	for {
-		select {
-		case newKeypers, ok := <-s.keyperAddedCh:
-			if !ok {
-				return nil
-			}
-			opts := logToCallOpts(ctx, &newKeypers.Raw)
-			newKeyperSet, err := s.newEvent(
-				ctx,
-				opts,
-				newKeypers.KeyperSetContract,
-				newKeypers.ActivationBlock,
-			)
-			if err != nil {
-				s.Log.Error(
-					"error while fetching new event",
-					"error",
-					err.Error(),
-				)
-				continue
-			}
-			err = s.Handler(ctx, newKeyperSet)
-			if err != nil {
-				s.Log.Error(
-					"handler for `NewKeyperSet` errored",
-					"error",
-					err.Error(),
-				)
-			}
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+func (s *KeyperSetSyncer) handle(ctx context.Context, ev *bindings.KeyperSetManagerKeyperSetAdded) error {
+	opts := logToCallOpts(ctx, &ev.Raw)
+	newKeyperSet, err := s.newEvent(
+		ctx,
+		opts,
+		ev.KeyperSetContract,
+		ev.ActivationBlock,
+	)
+	if err != nil {
+		return errors.Wrap(err, "fetch new event")
 	}
+	err = s.Handler(ctx, newKeyperSet)
+	if err != nil {
+		return errors.Wrap(err, "call handler")
+	}
+	return nil
 }

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -2,15 +2,17 @@ package syncer
 
 import (
 	"context"
-	"errors"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/pkg/errors"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/client"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/event"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/number"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/retry"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
 )
 
@@ -21,9 +23,16 @@ type UnsafeHeadSyncer struct {
 	// Handler to be manually triggered
 	// to handle their handler function
 	// before the own Handler is called:
-	SyncedHandler []ManualFilterHandler
+	SyncedHandler      []ManualFilterHandler
+	SyncStartBlock     *number.BlockNumber
+	FetchActiveAtStart bool
 
 	newLatestHeadCh chan *types.Header
+
+	syncHead      *types.Header
+	nextSyncBlock *big.Int
+	latestHead    *types.Header
+	headerCache   map[uint64]*types.Header
 }
 
 func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) error {
@@ -31,10 +40,35 @@ func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) err
 	if s.Handler == nil {
 		return errors.New("no handler registered")
 	}
+
+	s.headerCache = map[uint64]*types.Header{}
 	s.newLatestHeadCh = make(chan *types.Header, 1)
+	_, err := retry.FunctionCall(
+		ctx,
+		func(ctx context.Context) (bool, error) {
+			err := s.fetchInitialHeaders(ctx)
+			return err == nil, err
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "fetch initial latest header and sync start header")
+	}
+	s.SyncStartBlock = &number.BlockNumber{Int: s.syncHead.Number}
+	if s.FetchActiveAtStart {
+		for _, h := range s.SyncedHandler {
+			err := h.HandleVirtualEvent(ctx, s.SyncStartBlock)
+			if err != nil {
+				s.Log.Error("synced handler call errored, skipping", "error", err)
+			}
+		}
+	}
+	err = s.handle(ctx, s.syncHead, false)
+	if err != nil {
+		return errors.Wrap(err, "handle initial sync block")
+	}
+	s.nextSyncBlock = new(big.Int).Add(s.syncHead.Number, big.NewInt(1))
 
 	subs, err := s.Client.SubscribeNewHead(ctx, s.newLatestHeadCh)
-	// FIXME: what to do on subs.Error()
 	if err != nil {
 		return err
 	}
@@ -48,77 +82,226 @@ func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) err
 	return nil
 }
 
+func (s *UnsafeHeadSyncer) fetchInitialHeaders(ctx context.Context) error {
+	latest, err := s.Client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "fetch latest header")
+	}
+	s.latestHead = latest
+	if s.SyncStartBlock.IsLatest() {
+		s.syncHead = latest
+		return nil
+	}
+
+	start, err := s.Client.HeaderByNumber(ctx, s.SyncStartBlock.Int)
+	if err != nil {
+		return errors.Wrap(err, "fetch sync start header")
+	}
+	s.syncHead = start
+	return nil
+}
+
 func parseLogs() error {
 	return nil
 }
 
-func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
-	var currentBlock *big.Int
+func (s *UnsafeHeadSyncer) handle(ctx context.Context, newHeader *types.Header, reorg bool) error {
+	blockNum := number.BigToBlockNumber(newHeader.Number)
+	if reorg {
+		prevNum := new(big.Int).Sub(newHeader.Number, big.NewInt(1))
+		prevBlockNum := number.BigToBlockNumber(prevNum)
+		// Re-emit the previous block, to pre-emptively signal an
+		// incoming reorg. Like this a client is able to e.g.
+		// rewind changes first before processing the new
+		// events of the reorg
+		ev := &event.LatestBlock{
+			Number:    prevBlockNum,
+			BlockHash: newHeader.ParentHash,
+		}
+		err := s.Handler(ctx, ev)
+		if err != nil {
+			// XXX: return or log?
+			// return err
+			s.Log.Error(
+				"handler for `NewLatestBlock` errored",
+				"error",
+				err.Error(),
+			)
+		}
+	}
+
+	// TODO: check bloom filter for topic of all
+	// synced handlers and only call them if
+	// the bloomfilter retrieves something.
+	for _, h := range s.SyncedHandler {
+		// NOTE: this has to be blocking!
+		// So whenever this returns, it is expected
+		// that the handlers Handle function
+		// has been called and it returned.
+		err := h.QueryAndHandle(ctx, blockNum.Uint64())
+		if err != nil {
+			s.Log.Error("synced handler call errored, skipping", "error", err)
+		}
+	}
+	ev := &event.LatestBlock{
+		Number:    blockNum,
+		BlockHash: newHeader.Hash(),
+	}
+	err := s.Handler(ctx, ev)
+	if err != nil {
+		s.Log.Error(
+			"handler for `NewLatestBlock` errored",
+			"error",
+			err.Error(),
+		)
+	}
+	return nil
+}
+
+func (s *UnsafeHeadSyncer) fetchHeader(ctx context.Context, num *big.Int) (*types.Header, error) {
+	h, ok := s.headerCache[num.Uint64()]
+	if ok {
+		return h, nil
+	}
+	return s.Client.HeaderByNumber(ctx, num)
+}
+
+func (s *UnsafeHeadSyncer) reset(ctx context.Context) error {
+	// this means the latest head was reset - check wether that
+	// concerns the current sync status
+	switch s.latestHead.Number.Cmp(s.syncHead.Number) {
+	case 1:
+		// we didn't catch up to the reorg position, so it's safe to ignore
+		// TODO: delete the forward caches
+		return nil
+	case 0:
+		// we already processed the head we re-orged to
+		if s.latestHead.Hash().Cmp(s.syncHead.Hash()) == 0 {
+			return nil
+		}
+	}
+	// definite reorg
+	if err := s.handle(ctx, s.latestHead, true); err != nil {
+		return err
+	}
+	s.syncHead = s.latestHead
+	s.nextSyncBlock = new(big.Int).Add(s.latestHead.Number, big.NewInt(1))
+	return nil
+}
+
+func (s *UnsafeHeadSyncer) sync(ctx context.Context) (syncing bool, delay time.Duration, err error) {
+	var newHead *types.Header
+	s.Log.Info("syncing chain")
+
+	delta := new(big.Int).Sub(s.latestHead.Number, s.nextSyncBlock)
+	switch delta.Cmp(big.NewInt(0)) {
+	case 1:
+		// positive delta, we are still catching up
+		newHead, err = s.fetchHeader(ctx, s.nextSyncBlock)
+		syncing = true
+		delay = 1 * time.Second
+	case 0:
+		// next sync is latest head
+		// use the latest head
+		newHead = s.latestHead
+		syncing = false
+	case -1:
+		if delta.Cmp(big.NewInt(-1)) != 0 {
+			// next sync is more than one block further in the future.
+			// this could mean a reorg, but this should have been called before
+			// and it shouldn't come to this here
+			return false, delay, errors.New("unexpected reorg condition in sync")
+		}
+		// reorgs are handled outside, at the place new latest-head
+		// information arrives.
+		// next sync is 1 into the future.
+		// this means we called sync but are still waiting for the next latest head.
+		return false, delay, err
+	}
+	if err != nil {
+		return true, delay, err
+	}
+
+	if handleErr := s.handle(ctx, newHead, false); handleErr != nil {
+		return true, delay, handleErr
+	}
+	s.syncHead = newHead
+	delete(s.headerCache, newHead.Number.Uint64())
+	s.nextSyncBlock = new(big.Int).Add(newHead.Number, big.NewInt(1))
+
+	s.Log.Info("chain sync",
+		"synced-head-num", s.syncHead.Number.Uint64(),
+		"synced-head-hash", s.syncHead.Hash(),
+		"latest-head-num", s.latestHead.Number.Uint64(),
+		"latest-head-hash", s.latestHead.Hash(),
+	)
+	return syncing, delay, err
+}
+
+func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error { //nolint: gocyclo
+	t := time.NewTimer(0)
+	sync := t.C
+work:
 	for {
 		select {
+		case <-ctx.Done():
+			if sync != nil && !t.Stop() {
+				select {
+				case <-t.C:
+				// TODO: the non-blocking select is here as a
+				// precaution against an already emptied channel.
+				// This should not be necessary
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-sync:
+			syncing, delay, err := s.sync(ctx)
+			if err != nil {
+				s.Log.Error("error during unsafe head sync", "error", err)
+			}
+			if !syncing {
+				s.Log.Info("stop syncing from sync")
+				sync = nil
+				continue work
+			}
+			t.Reset(delay)
 		case newHeader, ok := <-s.newLatestHeadCh:
 			if !ok {
+				s.Log.Info("latest head stream closed, exiting handler loop")
 				return nil
 			}
-			blockNum := number.BigToBlockNumber(newHeader.Number)
-			if currentBlock != nil {
-				switch newHeader.Number.Cmp(currentBlock) {
-				case -1, 0:
-					prevNum := new(big.Int).Sub(newHeader.Number, big.NewInt(1))
-					prevBlockNum := number.BigToBlockNumber(prevNum)
-					// Re-emit the previous block, to pre-emptively signal an
-					// incoming reorg. Like this a client is able to e.g.
-					// rewind changes first before processing the new
-					// events of the reorg
-					ev := &event.LatestBlock{
-						Number:    prevBlockNum,
-						BlockHash: newHeader.ParentHash,
-					}
-					err := s.Handler(ctx, ev)
-					if err != nil {
-						// XXX: return or log?
-						// return err
-						s.Log.Error(
-							"handler for `NewLatestBlock` errored",
-							"error",
-							err.Error(),
-						)
-					}
-				case 1:
-					// expected
-				}
-			}
-
-			// TODO: check bloom filter for topic of all
-			// synced handlers and only call them if
-			// the bloomfilter retrieves something.
-			for _, h := range s.SyncedHandler {
-				// NOTE: this has to be blocking!
-				// So whenever this returns, it is expected
-				// that the handlers Handle function
-				// has been called and it returned.
-				err := h.QueryAndHandle(ctx, blockNum.Uint64())
-				if err != nil {
-					// XXX: return or log?
-					// return err
-					s.Log.Error("synced handler call errored, skipping", "error", err)
-				}
-			}
-			ev := &event.LatestBlock{
-				Number:    blockNum,
-				BlockHash: newHeader.Hash(),
-			}
-			err := s.Handler(ctx, ev)
-			if err != nil {
-				s.Log.Error(
-					"handler for `NewLatestBlock` errored",
-					"error",
-					err.Error(),
+			s.Log.Info("new latest head from l2 ws-stream", "block-number", newHeader.Number.Uint64())
+			if newHeader.Number.Cmp(s.latestHead.Number) <= 0 {
+				// reorg
+				s.Log.Info("new latest head is re-orging",
+					"old-block-number", s.latestHead.Number.Uint64(),
+					"new-block-number", newHeader.Number.Uint64(),
 				)
+
+				s.latestHead = newHeader
+				if err := s.reset(ctx); err != nil {
+					s.Log.Error("error resetting reorg", "error", err)
+				}
+				continue work
 			}
-			currentBlock = newHeader.Number
-		case <-ctx.Done():
-			return ctx.Err()
+			s.headerCache[newHeader.Number.Uint64()] = newHeader
+			s.latestHead = newHeader
+
+			if sync != nil && !t.Stop() {
+				// only if sync is still actively waiting,
+				// we need to drain the timer and reset it
+				select {
+				case <-t.C:
+				// TODO: the non-blocking select is here as a
+				// precaution against an already emptied channel.
+				// This should not be necessary
+				default:
+				}
+			}
+			t.Reset(0)
+			s.Log.Info("start syncing from latest head stream")
+			sync = t.C
 		}
 	}
 }

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -52,17 +53,45 @@ func parseLogs() error {
 }
 
 func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
+	var currentBlock *big.Int
 	for {
 		select {
 		case newHeader, ok := <-s.newLatestHeadCh:
 			if !ok {
 				return nil
 			}
+			blockNum := number.BigToBlockNumber(newHeader.Number)
+			if currentBlock != nil {
+				switch newHeader.Number.Cmp(currentBlock) {
+				case -1, 0:
+					prevNum := new(big.Int).Sub(newHeader.Number, big.NewInt(1))
+					prevBlockNum := number.BigToBlockNumber(prevNum)
+					// Re-emit the previous block, to pre-emptively signal an
+					// incoming reorg. Like this a client is able to e.g.
+					// rewind changes first before processing the new
+					// events of the reorg
+					ev := &event.LatestBlock{
+						Number:    prevBlockNum,
+						BlockHash: newHeader.ParentHash,
+					}
+					err := s.Handler(ctx, ev)
+					if err != nil {
+						// XXX: return or log?
+						// return err
+						s.Log.Error(
+							"handler for `NewLatestBlock` errored",
+							"error",
+							err.Error(),
+						)
+					}
+				case 1:
+					// expected
+				}
+			}
+
 			// TODO: check bloom filter for topic of all
 			// synced handlers and only call them if
 			// the bloomfilter retrieves something.
-
-			blockNum := number.BigToBlockNumber(newHeader.Number)
 			for _, h := range s.SyncedHandler {
 				// NOTE: this has to be blocking!
 				// So whenever this returns, it is expected
@@ -87,6 +116,7 @@ func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
 					err.Error(),
 				)
 			}
+			currentBlock = newHeader.Number
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/util.go
+++ b/rolling-shutter/medley/chainsync/syncer/util.go
@@ -20,6 +20,7 @@ var (
 
 type ManualFilterHandler interface {
 	QueryAndHandle(ctx context.Context, block uint64) error
+	HandleVirtualEvent(ctx context.Context, block *number.BlockNumber) error
 }
 
 func logToCallOpts(ctx context.Context, log *types.Log) *bind.CallOpts {


### PR DESCRIPTION
The chainsync did not handle the possibility of decreasing latest-head numbers on the unsafe head stream (reorgs).
Now, it indicates a reorg by first only calling the unsafe-head handler with the parent block of the newly re-orged latest head. This way a client can recognise a reorg, roll back all relevant state, and then still handle the events of the new latest head.
 
Additionally, the syncing mechanism for specific sync-start blocks was fixed.