### PR TITLE
Add unit-test for chainsync reorg capabilities

### DIFF
--- a/rolling-shutter/go.sum
+++ b/rolling-shutter/go.sum
@@ -830,8 +830,6 @@ github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYED
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/shutter-network/shop-contracts v0.0.0-20231220085304-80b8977d0bca h1:05Ghqw3FqH/UFuYIzc7z6GJyHk3HxAqY3iuY4L3x4Ow=
 github.com/shutter-network/shop-contracts v0.0.0-20231220085304-80b8977d0bca/go.mod h1:LEWXLRruvxq9fe2oKtJI3xfzbauhfWTjOczHN61RU+4=
-github.com/shutter-network/shutter/shlib v0.1.13 h1:9YloDJBdhFAKm2GMg4gBNeaJ+Mw9Qzeh5Kz9A2ayp1E=
-github.com/shutter-network/shutter/shlib v0.1.13/go.mod h1:RlYNZjx+pfKAi0arH+jfdlxG4kQ75UFzDfVjgCVYaUw=
 github.com/shutter-network/shutter/shlib v0.1.15 h1:HsAL3h5govZjFcHaox2Nf1DxawCjTcR0qNb+08YaM5c=
 github.com/shutter-network/shutter/shlib v0.1.15/go.mod h1:RlYNZjx+pfKAi0arH+jfdlxG4kQ75UFzDfVjgCVYaUw=
 github.com/shutter-network/txtypes v0.1.0 h1:QqdiiiB9AiBCSJ/ke6z1ZoDGfu2+1Lgpz5vHzVN4FKc=

--- a/rolling-shutter/medley/chainsync/client.go
+++ b/rolling-shutter/medley/chainsync/client.go
@@ -24,7 +24,7 @@ var noopLogger = &logger.NoopLogger{}
 var ErrServiceNotInstantiated = errors.New("service is not instantiated, pass a handler function option")
 
 type Client struct {
-	client.EthereumClient
+	client.SyncEthereumClient
 	log log.Logger
 
 	options *options
@@ -136,7 +136,7 @@ func (s *Client) BroadcastEonKey(ctx context.Context, eon uint64, eonPubKey []by
 // This value is cached, since it is not expected to change.
 func (s *Client) ChainID(ctx context.Context) (*big.Int, error) {
 	if s.chainID == nil {
-		cid, err := s.EthereumClient.ChainID(ctx)
+		cid, err := s.SyncEthereumClient.ChainID(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/rolling-shutter/medley/chainsync/client/client.go
+++ b/rolling-shutter/medley/chainsync/client/client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-type EthereumClient interface {
+type FullEthereumClient interface {
 	Close()
 	ChainID(ctx context.Context) (*big.Int, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
@@ -44,4 +44,15 @@ type EthereumClient interface {
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	SendTransaction(ctx context.Context, tx *types.Transaction) error
+}
+
+type SyncEthereumClient interface {
+	Close()
+	ChainID(ctx context.Context) (*big.Int, error)
+	BlockNumber(ctx context.Context) (uint64, error)
+	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
+	SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
 }

--- a/rolling-shutter/medley/chainsync/client/test.go
+++ b/rolling-shutter/medley/chainsync/client/test.go
@@ -1,0 +1,162 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+var _ SyncEthereumClient = &TestClient{}
+
+type TestClient struct {
+	headerChain            []*types.Header
+	latestHeadIndex        int
+	intialProgress         bool
+	latestHeadEmitter      []chan<- *types.Header
+	latestHeadSubscription []*Subscription
+}
+
+func NewSubscription(idx int) *Subscription {
+	return &Subscription{
+		idx: idx,
+		err: make(chan error, 1),
+	}
+}
+
+type Subscription struct {
+	idx int
+	err chan error
+}
+
+func (su *Subscription) Unsubscribe() {
+	// TODO: not implemented yet, but we don't want to panic
+}
+
+func (su *Subscription) Err() <-chan error {
+	return su.err
+}
+
+type TestClientController struct {
+	c *TestClient
+}
+
+func NewTestClient() (*TestClient, *TestClientController) {
+	c := &TestClient{
+		headerChain:     []*types.Header{},
+		latestHeadIndex: 0,
+	}
+	ctrl := &TestClientController{c}
+	return c, ctrl
+}
+
+func (c *TestClientController) ProgressHead() bool {
+	if c.c.latestHeadIndex >= len(c.c.headerChain)-1 {
+		return false
+	}
+	c.c.latestHeadIndex++
+	return true
+}
+
+func (c *TestClientController) EmitEvents(ctx context.Context) error {
+	if len(c.c.latestHeadEmitter) == 0 {
+		return nil
+	}
+	h := c.c.getLatestHeader()
+	for _, em := range c.c.latestHeadEmitter {
+		select {
+		case em <- h:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (c *TestClientController) AppendNextHeaders(h ...*types.Header) {
+	c.c.headerChain = append(c.c.headerChain, h...)
+}
+
+func (t *TestClient) ChainID(_ context.Context) (*big.Int, error) {
+	return big.NewInt(42), nil
+}
+
+func (t *TestClient) Close() {
+	// TODO: cleanup
+}
+
+func (t *TestClient) getLatestHeader() *types.Header {
+	if len(t.headerChain) == 0 {
+		return nil
+	}
+	return t.headerChain[t.latestHeadIndex]
+}
+
+func (t *TestClient) searchBlock(f func(*types.Header) bool) *types.Header {
+	for i := t.latestHeadIndex; i >= 0; i-- {
+		h := t.headerChain[i]
+		if f(h) {
+			return h
+		}
+	}
+	return nil
+}
+
+func (t *TestClient) searchBlockByNumber(number *big.Int) *types.Header {
+	return t.searchBlock(
+		func(h *types.Header) bool {
+			return h.Number.Cmp(number) == 0
+		})
+}
+
+func (t *TestClient) searchBlockByHash(hash common.Hash) *types.Header {
+	return t.searchBlock(
+		func(h *types.Header) bool {
+			return hash.Cmp(h.Hash()) == 0
+		})
+}
+
+func (t *TestClient) BlockNumber(_ context.Context) (uint64, error) {
+	return t.getLatestHeader().Nonce.Uint64(), nil
+}
+
+func (t *TestClient) HeaderByHash(_ context.Context, hash common.Hash) (*types.Header, error) {
+	h := t.searchBlockByHash(hash)
+	if h == nil {
+		// TODO: what error?
+	}
+	return h, nil
+}
+
+func (t *TestClient) HeaderByNumber(_ context.Context, number *big.Int) (*types.Header, error) {
+	if number == nil {
+		return t.getLatestHeader(), nil
+	}
+	h := t.searchBlockByNumber(number)
+	if h == nil {
+		// TODO: what error?
+	}
+	return h, nil
+}
+
+func (t *TestClient) SubscribeNewHead(_ context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	t.latestHeadEmitter = append(t.latestHeadEmitter, ch)
+	su := NewSubscription(len(t.latestHeadSubscription) - 1)
+	t.latestHeadSubscription = append(t.latestHeadSubscription, su)
+	// TODO: unsubscribe and deleting from the array
+	// TODO: filling error promise in the subscription
+	return su, nil
+}
+
+func (t *TestClient) FilterLogs(_ context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	panic(ErrNotImplemented)
+}
+
+func (t *TestClient) SubscribeFilterLogs(_ context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	panic(ErrNotImplemented)
+}

--- a/rolling-shutter/medley/chainsync/options.go
+++ b/rolling-shutter/medley/chainsync/options.go
@@ -24,7 +24,7 @@ type options struct {
 	keyperSetManagerAddress     *common.Address
 	keyBroadcastContractAddress *common.Address
 	clientURL                   string
-	ethClient                   syncclient.EthereumClient
+	ethClient                   syncclient.FullEthereumClient
 	logger                      log.Logger
 	runner                      service.Runner
 	syncStart                   *number.BlockNumber
@@ -122,7 +122,7 @@ func (o *options) applyHandler(c *Client) error {
 // of shutter clients background workers.
 func (o *options) apply(ctx context.Context, c *Client) error {
 	var (
-		client syncclient.EthereumClient
+		client syncclient.SyncEthereumClient
 		err    error
 	)
 	if o.clientURL != "" {
@@ -132,12 +132,12 @@ func (o *options) apply(ctx context.Context, c *Client) error {
 		}
 	}
 	client = o.ethClient
-	c.EthereumClient = client
+	c.SyncEthereumClient = client
 
 	// the nil passthrough will use "latest" for each call,
 	// but we want to harmonize and fix the sync start to a specific block.
 	if o.syncStart.IsLatest() {
-		latestBlock, err := c.EthereumClient.BlockNumber(ctx)
+		latestBlock, err := c.SyncEthereumClient.BlockNumber(ctx)
 		if err != nil {
 			return errors.Wrap(err, "polling latest block")
 		}
@@ -219,7 +219,7 @@ func WithLogger(l log.Logger) Option {
 	}
 }
 
-func WithClient(client syncclient.EthereumClient) Option {
+func WithClient(client syncclient.FullEthereumClient) Option {
 	return func(o *options) error {
 		o.ethClient = client
 		return nil

--- a/rolling-shutter/medley/chainsync/options.go
+++ b/rolling-shutter/medley/chainsync/options.go
@@ -39,15 +39,80 @@ type options struct {
 
 func (o *options) verify() error {
 	if o.clientURL != "" && o.ethClient != nil {
-		// TODO: error message
-		return errors.New("can't use client and client url")
+		return errors.New("'WithClient' and 'WithClientURL' options are mutually exclusive")
 	}
 	if o.clientURL == "" && o.ethClient == nil {
-		// TODO: error message
-		return errors.New("have to provide either url or client")
+		return errors.New("either 'WithClient' or 'WithClientURL' options are expected")
 	}
 	// TODO: check for the existence of the contract addresses depending on
 	// what handlers are not nil
+	return nil
+}
+
+func (o *options) applyHandler(c *Client) error {
+	var err error
+	syncedServices := []syncer.ManualFilterHandler{}
+
+	c.KeyperSetManager, err = bindings.NewKeyperSetManager(*o.keyperSetManagerAddress, o.ethClient)
+	if err != nil {
+		return err
+	}
+	c.kssync = &syncer.KeyperSetSyncer{
+		Client:   o.ethClient,
+		Contract: c.KeyperSetManager,
+		Log:      c.log,
+		Handler:  o.handlerKeyperSet,
+	}
+	if o.handlerKeyperSet != nil {
+		syncedServices = append(syncedServices, c.kssync)
+	}
+
+	c.KeyBroadcast, err = bindings.NewKeyBroadcastContract(*o.keyBroadcastContractAddress, o.ethClient)
+	if err != nil {
+		return err
+	}
+	c.epksync = &syncer.EonPubKeySyncer{
+		Client:           o.ethClient,
+		Log:              c.log,
+		KeyBroadcast:     c.KeyBroadcast,
+		KeyperSetManager: c.KeyperSetManager,
+		Handler:          o.handlerEonPublicKey,
+	}
+	if o.handlerEonPublicKey != nil {
+		syncedServices = append(syncedServices, c.epksync)
+	}
+	c.sssync = &syncer.ShutterStateSyncer{
+		Client:   o.ethClient,
+		Contract: c.KeyperSetManager,
+		Log:      c.log,
+		Handler:  o.handlerShutterState,
+	}
+	if o.handlerShutterState != nil {
+		syncedServices = append(syncedServices, c.sssync)
+	}
+
+	if o.handlerBlock == nil {
+		// Even if the user is not interested in handling new block events,
+		// the streaming block handler must be running in order to
+		// synchronize polling of new contract events.
+		// Since the handler function is always called, we need to
+		// inject a noop-handler
+		o.handlerBlock = func(ctx context.Context, lb *event.LatestBlock) error {
+			return nil
+		}
+	}
+
+	c.uhsync = &syncer.UnsafeHeadSyncer{
+		Client:             o.ethClient,
+		Log:                c.log,
+		Handler:            o.handlerBlock,
+		SyncedHandler:      syncedServices,
+		FetchActiveAtStart: o.fetchActivesAtSyncStart,
+		SyncStartBlock:     o.syncStart,
+	}
+	if o.handlerBlock != nil {
+		c.services = append(c.services, c.uhsync)
+	}
 	return nil
 }
 
@@ -67,16 +132,8 @@ func (o *options) apply(ctx context.Context, c *Client) error {
 		}
 	}
 	client = o.ethClient
-
 	c.EthereumClient = client
 
-	if o.logger != nil {
-		c.log = o.logger
-		// NOCHECKIN:
-		c.log.Info("got logger in options")
-	}
-
-	syncedServices := []syncer.ManualFilterHandler{}
 	// the nil passthrough will use "latest" for each call,
 	// but we want to harmonize and fix the sync start to a specific block.
 	if o.syncStart.IsLatest() {
@@ -87,82 +144,12 @@ func (o *options) apply(ctx context.Context, c *Client) error {
 		o.syncStart = number.NewBlockNumber(&latestBlock)
 	}
 
-	c.KeyperSetManager, err = bindings.NewKeyperSetManager(*o.keyperSetManagerAddress, client)
-	if err != nil {
-		return err
-	}
-	c.kssync = &syncer.KeyperSetSyncer{
-		Client:                  client,
-		Contract:                c.KeyperSetManager,
-		Log:                     c.log,
-		StartBlock:              o.syncStart,
-		Handler:                 o.handlerKeyperSet,
-		FetchActiveAtStartBlock: o.fetchActivesAtSyncStart,
-		DisableEventWatcher:     true,
-	}
-	if o.handlerKeyperSet != nil {
-		c.services = append(c.services, c.kssync)
-		syncedServices = append(syncedServices, c.kssync)
+	if o.logger != nil {
+		c.log = o.logger
 	}
 
-	c.KeyBroadcast, err = bindings.NewKeyBroadcastContract(*o.keyBroadcastContractAddress, client)
-	if err != nil {
-		return err
-	}
-	c.epksync = &syncer.EonPubKeySyncer{
-		Client:                  client,
-		Log:                     c.log,
-		KeyBroadcast:            c.KeyBroadcast,
-		KeyperSetManager:        c.KeyperSetManager,
-		Handler:                 o.handlerEonPublicKey,
-		StartBlock:              o.syncStart,
-		FetchActiveAtStartBlock: o.fetchActivesAtSyncStart,
-		DisableEventWatcher:     true,
-	}
-	if o.handlerEonPublicKey != nil {
-		c.services = append(c.services, c.epksync)
-		syncedServices = append(syncedServices, c.epksync)
-	}
-
-	c.sssync = &syncer.ShutterStateSyncer{
-		Client:                  client,
-		Contract:                c.KeyperSetManager,
-		Log:                     c.log,
-		Handler:                 o.handlerShutterState,
-		StartBlock:              o.syncStart,
-		FetchActiveAtStartBlock: o.fetchActivesAtSyncStart,
-		DisableEventWatcher:     true,
-	}
-	if o.handlerShutterState != nil {
-		c.services = append(c.services, c.sssync)
-		syncedServices = append(syncedServices, c.sssync)
-	}
-
-	if o.handlerBlock == nil {
-		// NOOP - but we need to run the UnsafeHeadSyncer.
-		// This is to keep the inner workings consisten,
-		// we use the DisableEventWatcher mechanism in combination
-		// with the UnsafeHeadSyncer instead of the streaming
-		// Watch... subscription on events.
-		// TODO: think about allowing the streaming events,
-		// when guaranteed event order (event1,event2,new-block-event)
-		// is not required
-		o.handlerBlock = func(ctx context.Context, lb *event.LatestBlock) error {
-			return nil
-		}
-	}
-
-	c.uhsync = &syncer.UnsafeHeadSyncer{
-		Client:        client,
-		Log:           c.log,
-		Handler:       o.handlerBlock,
-		SyncedHandler: syncedServices,
-	}
-	if o.handlerBlock != nil {
-		c.services = append(c.services, c.uhsync)
-	}
 	c.privKey = o.privKey
-	return nil
+	return o.applyHandler(c)
 }
 
 func defaultOptions() *options {

--- a/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
+++ b/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
@@ -17,7 +17,7 @@ import (
 var _ ManualFilterHandler = &EonPubKeySyncer{}
 
 type EonPubKeySyncer struct {
-	Client           client.EthereumClient
+	Client           client.SyncEthereumClient
 	Log              log.Logger
 	KeyBroadcast     *bindings.KeyBroadcastContract
 	KeyperSetManager *bindings.KeyperSetManager

--- a/rolling-shutter/medley/chainsync/syncer/keyperset.go
+++ b/rolling-shutter/medley/chainsync/syncer/keyperset.go
@@ -23,7 +23,7 @@ const channelSize = 10
 var _ ManualFilterHandler = &KeyperSetSyncer{}
 
 type KeyperSetSyncer struct {
-	Client   client.EthereumClient
+	Client   client.FullEthereumClient
 	Contract *bindings.KeyperSetManager
 	Log      log.Logger
 	Handler  event.KeyperSetHandler

--- a/rolling-shutter/medley/chainsync/syncer/keyperset.go
+++ b/rolling-shutter/medley/chainsync/syncer/keyperset.go
@@ -12,7 +12,6 @@ import (
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/client"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/event"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/number"
-	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
 )
 
 func makeCallError(attrName string, err error) error {
@@ -24,114 +23,67 @@ const channelSize = 10
 var _ ManualFilterHandler = &KeyperSetSyncer{}
 
 type KeyperSetSyncer struct {
-	Client     client.EthereumClient
-	Contract   *bindings.KeyperSetManager
-	Log        log.Logger
-	StartBlock *number.BlockNumber
-	Handler    event.KeyperSetHandler
-	// disable this when the QueryAndHandle manual polling should be used:
-	FetchActiveAtStartBlock bool
-	DisableEventWatcher     bool
-
-	keyperAddedCh chan *bindings.KeyperSetManagerKeyperSetAdded
+	Client   client.EthereumClient
+	Contract *bindings.KeyperSetManager
+	Log      log.Logger
+	Handler  event.KeyperSetHandler
 }
 
 func (s *KeyperSetSyncer) QueryAndHandle(ctx context.Context, block uint64) error {
 	opts := &bind.FilterOpts{
-		// FIXME: does this work, or do we need index -1 or something?
 		Start:   block,
 		End:     &block,
 		Context: ctx,
 	}
 	iter, err := s.Contract.FilterKeyperSetAdded(opts)
-	// TODO: what errors possible?
 	if err != nil {
 		return err
 	}
 	defer iter.Close()
 
 	for iter.Next() {
-		select {
-		// XXX: this can be nil during the handlers startup.
-		// As far as I understand, a nil channel is never selected.
-		// Will it be selected as soon as the channel is not nil anymore?
-		case s.keyperAddedCh <- iter.Event:
-		case <-ctx.Done():
-			return ctx.Err()
+		err := s.handle(ctx, iter.Event)
+		if err != nil {
+			s.Log.Error(
+				"handler for `NewKeyperSet` errored",
+				"error",
+				err.Error(),
+			)
 		}
 	}
-	// XXX: it looks like this is nil when the iterator is
-	// exhausted without failures
 	if err := iter.Error(); err != nil {
 		return errors.Wrap(err, "filter iterator error")
 	}
 	return nil
 }
 
-func (s *KeyperSetSyncer) Start(ctx context.Context, runner service.Runner) error {
-	if s.Handler == nil {
-		return errors.New("no handler registered")
+func (s *KeyperSetSyncer) HandleVirtualEvent(ctx context.Context, block *number.BlockNumber) error {
+	initial, err := s.getInitialKeyperSets(ctx, block)
+	if err != nil {
+		return err
 	}
-
-	// the latest block still has to be fixed.
-	// otherwise we could skip some block events
-	// between the initial poll and the subscription.
-	if s.StartBlock.IsLatest() {
-		latest, err := s.Client.BlockNumber(ctx)
+	for _, ks := range initial {
+		err = s.Handler(ctx, ks)
 		if err != nil {
-			return err
-		}
-		s.StartBlock.SetUint64(latest)
-	}
-
-	watchOpts := &bind.WatchOpts{
-		Start:   s.StartBlock.ToUInt64Ptr(),
-		Context: ctx,
-	}
-
-	if s.FetchActiveAtStartBlock {
-		initial, err := s.getInitialKeyperSets(ctx)
-		if err != nil {
-			return err
-		}
-		for _, ks := range initial {
-			err = s.Handler(ctx, ks)
-			if err != nil {
-				s.Log.Error(
-					"handler for `NewKeyperSet` errored for initial sync",
-					"error",
-					err.Error(),
-				)
-			}
+			s.Log.Error(
+				"handler for `NewKeyperSet` errored for initial sync",
+				"error",
+				err.Error(),
+			)
 		}
 	}
-	s.keyperAddedCh = make(chan *bindings.KeyperSetManagerKeyperSetAdded, channelSize)
-	runner.Defer(func() {
-		close(s.keyperAddedCh)
-	})
-	if !s.DisableEventWatcher {
-		subs, err := s.Contract.WatchKeyperSetAdded(watchOpts, s.keyperAddedCh)
-		// FIXME: what to do on subs.Error()
-		if err != nil {
-			return err
-		}
-		runner.Defer(subs.Unsubscribe)
-	}
-	runner.Go(func() error {
-		return s.watchNewKeypersService(ctx)
-	})
 	return nil
 }
 
-func (s *KeyperSetSyncer) getInitialKeyperSets(ctx context.Context) ([]*event.KeyperSet, error) {
+func (s *KeyperSetSyncer) getInitialKeyperSets(ctx context.Context, block *number.BlockNumber) ([]*event.KeyperSet, error) {
 	opts := &bind.CallOpts{
 		Context:     ctx,
-		BlockNumber: s.StartBlock.Int,
+		BlockNumber: block.Int,
 	}
 	if err := guardCallOpts(opts, false); err != nil {
 		return nil, err
 	}
-	bn := s.StartBlock.ToUInt64Ptr()
+	bn := block.ToUInt64Ptr()
 	if bn == nil {
 		// this should not be the case
 		return nil, errors.New("start block is 'latest'")
@@ -140,7 +92,7 @@ func (s *KeyperSetSyncer) getInitialKeyperSets(ctx context.Context) ([]*event.Ke
 	initialKeyperSets := []*event.KeyperSet{}
 	// this blocknumber specifies the argument to the contract
 	// getter
-	ks, err := s.GetKeyperSetForBlock(ctx, opts, s.StartBlock)
+	ks, err := s.GetKeyperSetForBlock(ctx, opts, block)
 	if err != nil {
 		return nil, err
 	}
@@ -250,38 +202,20 @@ func (s *KeyperSetSyncer) newEvent(
 	}, nil
 }
 
-func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context) error {
-	for {
-		select {
-		case newKeypers, ok := <-s.keyperAddedCh:
-			if !ok {
-				return nil
-			}
-			opts := logToCallOpts(ctx, &newKeypers.Raw)
-			newKeyperSet, err := s.newEvent(
-				ctx,
-				opts,
-				newKeypers.KeyperSetContract,
-				newKeypers.ActivationBlock,
-			)
-			if err != nil {
-				s.Log.Error(
-					"error while fetching new event",
-					"error",
-					err.Error(),
-				)
-				continue
-			}
-			err = s.Handler(ctx, newKeyperSet)
-			if err != nil {
-				s.Log.Error(
-					"handler for `NewKeyperSet` errored",
-					"error",
-					err.Error(),
-				)
-			}
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+func (s *KeyperSetSyncer) handle(ctx context.Context, ev *bindings.KeyperSetManagerKeyperSetAdded) error {
+	opts := logToCallOpts(ctx, &ev.Raw)
+	newKeyperSet, err := s.newEvent(
+		ctx,
+		opts,
+		ev.KeyperSetContract,
+		ev.ActivationBlock,
+	)
+	if err != nil {
+		return errors.Wrap(err, "fetch new event")
 	}
+	err = s.Handler(ctx, newKeyperSet)
+	if err != nil {
+		return errors.Wrap(err, "call handler")
+	}
+	return nil
 }

--- a/rolling-shutter/medley/chainsync/syncer/shutterstate.go
+++ b/rolling-shutter/medley/chainsync/syncer/shutterstate.go
@@ -16,7 +16,7 @@ import (
 var _ ManualFilterHandler = &ShutterStateSyncer{}
 
 type ShutterStateSyncer struct {
-	Client   client.EthereumClient
+	Client   client.SyncEthereumClient
 	Contract *bindings.KeyperSetManager
 	Log      log.Logger
 	Handler  event.ShutterStateHandler

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -2,15 +2,17 @@ package syncer
 
 import (
 	"context"
-	"errors"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/pkg/errors"
 
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/client"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/event"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/number"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/retry"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
 )
 
@@ -21,9 +23,16 @@ type UnsafeHeadSyncer struct {
 	// Handler to be manually triggered
 	// to handle their handler function
 	// before the own Handler is called:
-	SyncedHandler []ManualFilterHandler
+	SyncedHandler      []ManualFilterHandler
+	SyncStartBlock     *number.BlockNumber
+	FetchActiveAtStart bool
 
 	newLatestHeadCh chan *types.Header
+
+	syncHead      *types.Header
+	nextSyncBlock *big.Int
+	latestHead    *types.Header
+	headerCache   map[uint64]*types.Header
 }
 
 func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) error {
@@ -31,10 +40,35 @@ func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) err
 	if s.Handler == nil {
 		return errors.New("no handler registered")
 	}
+
+	s.headerCache = map[uint64]*types.Header{}
 	s.newLatestHeadCh = make(chan *types.Header, 1)
+	_, err := retry.FunctionCall(
+		ctx,
+		func(ctx context.Context) (bool, error) {
+			err := s.fetchInitialHeaders(ctx)
+			return err == nil, err
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "fetch initial latest header and sync start header")
+	}
+	s.SyncStartBlock = &number.BlockNumber{Int: s.syncHead.Number}
+	if s.FetchActiveAtStart {
+		for _, h := range s.SyncedHandler {
+			err := h.HandleVirtualEvent(ctx, s.SyncStartBlock)
+			if err != nil {
+				s.Log.Error("synced handler call errored, skipping", "error", err)
+			}
+		}
+	}
+	err = s.handle(ctx, s.syncHead, false)
+	if err != nil {
+		return errors.Wrap(err, "handle initial sync block")
+	}
+	s.nextSyncBlock = new(big.Int).Add(s.syncHead.Number, big.NewInt(1))
 
 	subs, err := s.Client.SubscribeNewHead(ctx, s.newLatestHeadCh)
-	// FIXME: what to do on subs.Error()
 	if err != nil {
 		return err
 	}
@@ -48,77 +82,226 @@ func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) err
 	return nil
 }
 
+func (s *UnsafeHeadSyncer) fetchInitialHeaders(ctx context.Context) error {
+	latest, err := s.Client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "fetch latest header")
+	}
+	s.latestHead = latest
+	if s.SyncStartBlock.IsLatest() {
+		s.syncHead = latest
+		return nil
+	}
+
+	start, err := s.Client.HeaderByNumber(ctx, s.SyncStartBlock.Int)
+	if err != nil {
+		return errors.Wrap(err, "fetch sync start header")
+	}
+	s.syncHead = start
+	return nil
+}
+
 func parseLogs() error {
 	return nil
 }
 
-func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
-	var currentBlock *big.Int
+func (s *UnsafeHeadSyncer) handle(ctx context.Context, newHeader *types.Header, reorg bool) error {
+	blockNum := number.BigToBlockNumber(newHeader.Number)
+	if reorg {
+		prevNum := new(big.Int).Sub(newHeader.Number, big.NewInt(1))
+		prevBlockNum := number.BigToBlockNumber(prevNum)
+		// Re-emit the previous block, to pre-emptively signal an
+		// incoming reorg. Like this a client is able to e.g.
+		// rewind changes first before processing the new
+		// events of the reorg
+		ev := &event.LatestBlock{
+			Number:    prevBlockNum,
+			BlockHash: newHeader.ParentHash,
+		}
+		err := s.Handler(ctx, ev)
+		if err != nil {
+			// XXX: return or log?
+			// return err
+			s.Log.Error(
+				"handler for `NewLatestBlock` errored",
+				"error",
+				err.Error(),
+			)
+		}
+	}
+
+	// TODO: check bloom filter for topic of all
+	// synced handlers and only call them if
+	// the bloomfilter retrieves something.
+	for _, h := range s.SyncedHandler {
+		// NOTE: this has to be blocking!
+		// So whenever this returns, it is expected
+		// that the handlers Handle function
+		// has been called and it returned.
+		err := h.QueryAndHandle(ctx, blockNum.Uint64())
+		if err != nil {
+			s.Log.Error("synced handler call errored, skipping", "error", err)
+		}
+	}
+	ev := &event.LatestBlock{
+		Number:    blockNum,
+		BlockHash: newHeader.Hash(),
+	}
+	err := s.Handler(ctx, ev)
+	if err != nil {
+		s.Log.Error(
+			"handler for `NewLatestBlock` errored",
+			"error",
+			err.Error(),
+		)
+	}
+	return nil
+}
+
+func (s *UnsafeHeadSyncer) fetchHeader(ctx context.Context, num *big.Int) (*types.Header, error) {
+	h, ok := s.headerCache[num.Uint64()]
+	if ok {
+		return h, nil
+	}
+	return s.Client.HeaderByNumber(ctx, num)
+}
+
+func (s *UnsafeHeadSyncer) reset(ctx context.Context) error {
+	// this means the latest head was reset - check wether that
+	// concerns the current sync status
+	switch s.latestHead.Number.Cmp(s.syncHead.Number) {
+	case 1:
+		// we didn't catch up to the reorg position, so it's safe to ignore
+		// TODO: delete the forward caches
+		return nil
+	case 0:
+		// we already processed the head we re-orged to
+		if s.latestHead.Hash().Cmp(s.syncHead.Hash()) == 0 {
+			return nil
+		}
+	}
+	// definite reorg
+	if err := s.handle(ctx, s.latestHead, true); err != nil {
+		return err
+	}
+	s.syncHead = s.latestHead
+	s.nextSyncBlock = new(big.Int).Add(s.latestHead.Number, big.NewInt(1))
+	return nil
+}
+
+func (s *UnsafeHeadSyncer) sync(ctx context.Context) (syncing bool, delay time.Duration, err error) {
+	var newHead *types.Header
+	s.Log.Info("syncing chain")
+
+	delta := new(big.Int).Sub(s.latestHead.Number, s.nextSyncBlock)
+	switch delta.Cmp(big.NewInt(0)) {
+	case 1:
+		// positive delta, we are still catching up
+		newHead, err = s.fetchHeader(ctx, s.nextSyncBlock)
+		syncing = true
+		delay = 1 * time.Second
+	case 0:
+		// next sync is latest head
+		// use the latest head
+		newHead = s.latestHead
+		syncing = false
+	case -1:
+		if delta.Cmp(big.NewInt(-1)) != 0 {
+			// next sync is more than one block further in the future.
+			// this could mean a reorg, but this should have been called before
+			// and it shouldn't come to this here
+			return false, delay, errors.New("unexpected reorg condition in sync")
+		}
+		// reorgs are handled outside, at the place new latest-head
+		// information arrives.
+		// next sync is 1 into the future.
+		// this means we called sync but are still waiting for the next latest head.
+		return false, delay, err
+	}
+	if err != nil {
+		return true, delay, err
+	}
+
+	if handleErr := s.handle(ctx, newHead, false); handleErr != nil {
+		return true, delay, handleErr
+	}
+	s.syncHead = newHead
+	delete(s.headerCache, newHead.Number.Uint64())
+	s.nextSyncBlock = new(big.Int).Add(newHead.Number, big.NewInt(1))
+
+	s.Log.Info("chain sync",
+		"synced-head-num", s.syncHead.Number.Uint64(),
+		"synced-head-hash", s.syncHead.Hash(),
+		"latest-head-num", s.latestHead.Number.Uint64(),
+		"latest-head-hash", s.latestHead.Hash(),
+	)
+	return syncing, delay, err
+}
+
+func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error { //nolint: gocyclo
+	t := time.NewTimer(0)
+	sync := t.C
+work:
 	for {
 		select {
+		case <-ctx.Done():
+			if sync != nil && !t.Stop() {
+				select {
+				case <-t.C:
+				// TODO: the non-blocking select is here as a
+				// precaution against an already emptied channel.
+				// This should not be necessary
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-sync:
+			syncing, delay, err := s.sync(ctx)
+			if err != nil {
+				s.Log.Error("error during unsafe head sync", "error", err)
+			}
+			if !syncing {
+				s.Log.Info("stop syncing from sync")
+				sync = nil
+				continue work
+			}
+			t.Reset(delay)
 		case newHeader, ok := <-s.newLatestHeadCh:
 			if !ok {
+				s.Log.Info("latest head stream closed, exiting handler loop")
 				return nil
 			}
-			blockNum := number.BigToBlockNumber(newHeader.Number)
-			if currentBlock != nil {
-				switch newHeader.Number.Cmp(currentBlock) {
-				case -1, 0:
-					prevNum := new(big.Int).Sub(newHeader.Number, big.NewInt(1))
-					prevBlockNum := number.BigToBlockNumber(prevNum)
-					// Re-emit the previous block, to pre-emptively signal an
-					// incoming reorg. Like this a client is able to e.g.
-					// rewind changes first before processing the new
-					// events of the reorg
-					ev := &event.LatestBlock{
-						Number:    prevBlockNum,
-						BlockHash: newHeader.ParentHash,
-					}
-					err := s.Handler(ctx, ev)
-					if err != nil {
-						// XXX: return or log?
-						// return err
-						s.Log.Error(
-							"handler for `NewLatestBlock` errored",
-							"error",
-							err.Error(),
-						)
-					}
-				case 1:
-					// expected
-				}
-			}
-
-			// TODO: check bloom filter for topic of all
-			// synced handlers and only call them if
-			// the bloomfilter retrieves something.
-			for _, h := range s.SyncedHandler {
-				// NOTE: this has to be blocking!
-				// So whenever this returns, it is expected
-				// that the handlers Handle function
-				// has been called and it returned.
-				err := h.QueryAndHandle(ctx, blockNum.Uint64())
-				if err != nil {
-					// XXX: return or log?
-					// return err
-					s.Log.Error("synced handler call errored, skipping", "error", err)
-				}
-			}
-			ev := &event.LatestBlock{
-				Number:    blockNum,
-				BlockHash: newHeader.Hash(),
-			}
-			err := s.Handler(ctx, ev)
-			if err != nil {
-				s.Log.Error(
-					"handler for `NewLatestBlock` errored",
-					"error",
-					err.Error(),
+			s.Log.Info("new latest head from l2 ws-stream", "block-number", newHeader.Number.Uint64())
+			if newHeader.Number.Cmp(s.latestHead.Number) <= 0 {
+				// reorg
+				s.Log.Info("new latest head is re-orging",
+					"old-block-number", s.latestHead.Number.Uint64(),
+					"new-block-number", newHeader.Number.Uint64(),
 				)
+
+				s.latestHead = newHeader
+				if err := s.reset(ctx); err != nil {
+					s.Log.Error("error resetting reorg", "error", err)
+				}
+				continue work
 			}
-			currentBlock = newHeader.Number
-		case <-ctx.Done():
-			return ctx.Err()
+			s.headerCache[newHeader.Number.Uint64()] = newHeader
+			s.latestHead = newHeader
+
+			if sync != nil && !t.Stop() {
+				// only if sync is still actively waiting,
+				// we need to drain the timer and reset it
+				select {
+				case <-t.C:
+				// TODO: the non-blocking select is here as a
+				// precaution against an already emptied channel.
+				// This should not be necessary
+				default:
+				}
+			}
+			t.Reset(0)
+			s.Log.Info("start syncing from latest head stream")
+			sync = t.C
 		}
 	}
 }

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -52,17 +53,45 @@ func parseLogs() error {
 }
 
 func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
+	var currentBlock *big.Int
 	for {
 		select {
 		case newHeader, ok := <-s.newLatestHeadCh:
 			if !ok {
 				return nil
 			}
+			blockNum := number.BigToBlockNumber(newHeader.Number)
+			if currentBlock != nil {
+				switch newHeader.Number.Cmp(currentBlock) {
+				case -1, 0:
+					prevNum := new(big.Int).Sub(newHeader.Number, big.NewInt(1))
+					prevBlockNum := number.BigToBlockNumber(prevNum)
+					// Re-emit the previous block, to pre-emptively signal an
+					// incoming reorg. Like this a client is able to e.g.
+					// rewind changes first before processing the new
+					// events of the reorg
+					ev := &event.LatestBlock{
+						Number:    prevBlockNum,
+						BlockHash: newHeader.ParentHash,
+					}
+					err := s.Handler(ctx, ev)
+					if err != nil {
+						// XXX: return or log?
+						// return err
+						s.Log.Error(
+							"handler for `NewLatestBlock` errored",
+							"error",
+							err.Error(),
+						)
+					}
+				case 1:
+					// expected
+				}
+			}
+
 			// TODO: check bloom filter for topic of all
 			// synced handlers and only call them if
 			// the bloomfilter retrieves something.
-
-			blockNum := number.BigToBlockNumber(newHeader.Number)
 			for _, h := range s.SyncedHandler {
 				// NOTE: this has to be blocking!
 				// So whenever this returns, it is expected
@@ -87,6 +116,7 @@ func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
 					err.Error(),
 				)
 			}
+			currentBlock = newHeader.Number
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -17,7 +17,7 @@ import (
 )
 
 type UnsafeHeadSyncer struct {
-	Client  client.EthereumClient
+	Client  client.SyncEthereumClient
 	Log     log.Logger
 	Handler event.BlockHandler
 	// Handler to be manually triggered

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead_test.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead_test.go
@@ -1,0 +1,112 @@
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/client"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/chainsync/event"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/encodeable/number"
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
+	"gotest.tools/v3/assert"
+)
+
+func MakeChain(start int64, startParent common.Hash, numHeader uint, seed int64) []*types.Header {
+	n := numHeader
+	parent := startParent
+	num := big.NewInt(start)
+	h := []*types.Header{}
+
+	// change the hashes for different seeds
+	mixinh := common.BigToHash(big.NewInt(seed))
+	for n > 0 {
+		head := &types.Header{
+			ParentHash: parent,
+			Number:     num,
+			MixDigest:  mixinh,
+		}
+		h = append(h, head)
+		num = new(big.Int).Add(num, big.NewInt(1))
+		parent = head.Hash()
+		n--
+	}
+	return h
+}
+
+func TestReorg(t *testing.T) {
+	headersBeforeReorg := MakeChain(1, common.BigToHash(big.NewInt(0)), 10, 42)
+	branchOff := headersBeforeReorg[5]
+	// block number 5 will be reorged
+	headersReorgBranch := MakeChain(branchOff.Number.Int64()+1, branchOff.Hash(), 10, 43)
+	clnt, ctl := client.NewTestClient()
+	ctl.AppendNextHeaders(headersBeforeReorg...)
+	ctl.AppendNextHeaders(headersReorgBranch...)
+
+	handlerBlock := make(chan *event.LatestBlock, 1)
+
+	h := &UnsafeHeadSyncer{
+		Client: clnt,
+		Log:    log.New(),
+		Handler: func(_ context.Context, ev *event.LatestBlock) error {
+			handlerBlock <- ev
+			return nil
+		},
+		SyncedHandler:      []ManualFilterHandler{},
+		SyncStartBlock:     number.NewBlockNumber(nil),
+		FetchActiveAtStart: false,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	service.RunBackground(ctx, h)
+
+	// intitial sync is independent of the subscription,
+	// this will get polled from the eth client
+	b := <-handlerBlock
+	assert.Assert(t, b.Number.Cmp(headersBeforeReorg[0].Number) == 0)
+	idx := 1
+	for {
+		ok := ctl.ProgressHead()
+		assert.Assert(t, ok)
+		err := ctl.EmitEvents(ctx)
+		assert.NilError(t, err)
+
+		b = <-handlerBlock
+		assert.Equal(t, b.Number.Uint64(), headersBeforeReorg[idx].Number.Uint64(), fmt.Sprintf("block number equal for idx %d", idx))
+		assert.Equal(t, b.BlockHash, headersBeforeReorg[idx].Hash())
+		idx++
+		if idx == len(headersBeforeReorg) {
+			break
+		}
+	}
+	ok := ctl.ProgressHead()
+	assert.Assert(t, ok)
+	err := ctl.EmitEvents(ctx)
+	assert.NilError(t, err)
+	b = <-handlerBlock
+	// now the reorg should have happened.
+	// the handler should have emitted an "artificial" latest head
+	// event for the block BEFORE the re-orged block
+	assert.Equal(t, b.Number.Uint64(), headersReorgBranch[0].Number.Uint64()-1, "block number equal for reorg")
+	assert.Equal(t, b.BlockHash, headersReorgBranch[0].ParentHash)
+	idx = 0
+	for ctl.ProgressHead() {
+		assert.Assert(t, ok)
+		err := ctl.EmitEvents(ctx)
+		assert.NilError(t, err)
+
+		b := <-handlerBlock
+		assert.Equal(t, b.Number.Uint64(), headersReorgBranch[idx].Number.Uint64(), fmt.Sprintf("block number equal for idx %d", idx))
+		assert.Equal(t, b.BlockHash, headersReorgBranch[idx].Hash())
+		idx++
+		if idx == len(headersReorgBranch) {
+			break
+		}
+	}
+}

--- a/rolling-shutter/medley/chainsync/syncer/util.go
+++ b/rolling-shutter/medley/chainsync/syncer/util.go
@@ -45,7 +45,7 @@ func guardCallOpts(opts *bind.CallOpts, allowLatest bool) error {
 	return nil
 }
 
-func fixCallOpts(ctx context.Context, c client.EthereumClient, opts *bind.CallOpts) (*bind.CallOpts, *uint64, error) {
+func fixCallOpts(ctx context.Context, c client.SyncEthereumClient, opts *bind.CallOpts) (*bind.CallOpts, *uint64, error) {
 	err := guardCallOpts(opts, false)
 	if err == nil {
 		return opts, nil, nil

--- a/rolling-shutter/medley/chainsync/syncer/util.go
+++ b/rolling-shutter/medley/chainsync/syncer/util.go
@@ -20,6 +20,7 @@ var (
 
 type ManualFilterHandler interface {
 	QueryAndHandle(ctx context.Context, block uint64) error
+	HandleVirtualEvent(ctx context.Context, block *number.BlockNumber) error
 }
 
 func logToCallOpts(ctx context.Context, log *types.Log) *bind.CallOpts {


### PR DESCRIPTION
The chainsync handles re-orgs now - this PR adds a dummy ethereum client and a test of the re-org capabilities of the chainsync unsafe head handler.