### PR TITLE
Fix duplicate keyper set error

### DIFF
--- a/rolling-shutter/chainobserver/db/keyper/keyper.sqlc.gen.go
+++ b/rolling-shutter/chainobserver/db/keyper/keyper.sqlc.gen.go
@@ -81,7 +81,7 @@ INSERT INTO keyper_set (
     threshold
 ) VALUES (
     $1, $2, $3, $4
-)
+) ON CONFLICT DO NOTHING
 `
 
 type InsertKeyperSetParams struct {

--- a/rolling-shutter/chainobserver/db/keyper/sql/queries/keyper.sql
+++ b/rolling-shutter/chainobserver/db/keyper/sql/queries/keyper.sql
@@ -6,7 +6,7 @@ INSERT INTO keyper_set (
     threshold
 ) VALUES (
     $1, $2, $3, $4
-);
+) ON CONFLICT DO NOTHING;
 
 -- name: GetKeyperSetByKeyperConfigIndex :one
 SELECT * FROM keyper_set WHERE keyper_config_index=$1;


### PR DESCRIPTION
On startup, the chainsyncer gives all keyper sets it can find in the keyper set manager to its subscribers, no matter if they are actually new or already in the db. This results in duplicate primary key errors when we try to insert them a second time.

To fix this, the SQL query now does not insert the keyper set if it is already present.