### PR TITLE
Don't close channels as receivers

### DIFF
--- a/rolling-shutter/keyperimpl/gnosis/keyper.go
+++ b/rolling-shutter/keyperimpl/gnosis/keyper.go
@@ -73,10 +73,6 @@ func (kpr *Keyper) Start(ctx context.Context, runner service.Runner) error {
 	kpr.newKeyperSets = make(chan *syncevent.KeyperSet)
 	kpr.newEonPublicKeys = make(chan keyper.EonPublicKey)
 	kpr.decryptionTriggerChannel = make(chan *broker.Event[*epochkghandler.DecryptionTrigger])
-	runner.Defer(func() { close(kpr.newBlocks) })
-	runner.Defer(func() { close(kpr.newKeyperSets) })
-	runner.Defer(func() { close(kpr.newEonPublicKeys) })
-	runner.Defer(func() { close(kpr.decryptionTriggerChannel) })
 
 	kpr.latestTriggeredSlot = nil
 

--- a/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
+++ b/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
@@ -56,9 +56,6 @@ func (s *EonPubKeySyncer) Start(ctx context.Context, runner service.Runner) erro
 		Context: ctx,
 	}
 	s.keyBroadcastCh = make(chan *bindings.KeyBroadcastContractEonKeyBroadcast, channelSize)
-	runner.Defer(func() {
-		close(s.keyBroadcastCh)
-	})
 	subs, err := s.KeyBroadcast.WatchEonKeyBroadcast(watchOpts, s.keyBroadcastCh)
 	// FIXME: what to do on subs.Error()
 	if err != nil {

--- a/rolling-shutter/medley/chainsync/syncer/keyperset.go
+++ b/rolling-shutter/medley/chainsync/syncer/keyperset.go
@@ -66,9 +66,6 @@ func (s *KeyperSetSyncer) Start(ctx context.Context, runner service.Runner) erro
 		}
 	}
 	s.keyperAddedCh = make(chan *bindings.KeyperSetManagerKeyperSetAdded, channelSize)
-	runner.Defer(func() {
-		close(s.keyperAddedCh)
-	})
 	subs, err := s.Contract.WatchKeyperSetAdded(watchOpts, s.keyperAddedCh)
 	// FIXME: what to do on subs.Error()
 	if err != nil {

--- a/rolling-shutter/medley/chainsync/syncer/shutterstate.go
+++ b/rolling-shutter/medley/chainsync/syncer/shutterstate.go
@@ -55,9 +55,6 @@ func (s *ShutterStateSyncer) Start(ctx context.Context, runner service.Runner) e
 		return err
 	}
 	runner.Defer(subs.Unsubscribe)
-	runner.Defer(func() {
-		close(s.pausedCh)
-	})
 
 	s.unpausedCh = make(chan *bindings.KeyperSetManagerUnpaused)
 	subs, err = s.Contract.WatchUnpaused(watchOpts, s.unpausedCh)
@@ -66,9 +63,6 @@ func (s *ShutterStateSyncer) Start(ctx context.Context, runner service.Runner) e
 		return err
 	}
 	runner.Defer(subs.Unsubscribe)
-	runner.Defer(func() {
-		close(s.unpausedCh)
-	})
 
 	runner.Go(func() error {
 		return s.watchPaused(ctx)

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -33,9 +33,6 @@ func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) err
 		return err
 	}
 	runner.Defer(subs.Unsubscribe)
-	runner.Defer(func() {
-		close(s.newLatestHeadCh)
-	})
 	runner.Go(func() error {
 		return s.watchLatestUnsafeHead(ctx)
 	})


### PR DESCRIPTION
In many places in the code, a receiver creates a channel, passes it to the sender, and closes it on shutdown. This sometimes results in panics due to sends on a closed channel, because the receiver oftentimes cannot guarantee that the sender has stopped sending. In general, only the sender should close channels, and only if necessary in order to notify the receiver that no more elements are coming. To fix this, we just remove the close statements as they are not needed.

Closes #464. With this commit, I was unable to reproduce the error.