### PR TITLE
Downgrade "error dialing peer" log to debug

### DIFF
--- a/rolling-shutter/p2p/dht.go
+++ b/rolling-shutter/p2p/dht.go
@@ -93,7 +93,10 @@ func findPeers(ctx context.Context, h host.Host, d discovery.Discoverer, ns stri
 				if h.Network().Connectedness(p.ID) != network.Connected {
 					_, err = h.Network().DialPeer(ctx, p.ID)
 					if err != nil {
-						log.Error().Err(err).Str("peer", p.ID.String()).Msg("error dialing peer")
+						log.Debug().
+							Err(err).
+							Str("peer", p.ID.String()).
+							Msg("error dialing peer")
 						failedDials++
 					}
 					newConnections++


### PR DESCRIPTION
In production we see a lot of these messages. Failing to dial a peer is usually because the peer is unreachable which is not an error, so logging it as an error is misleading.

~Closes #467.~