### PR TITLE
Use msg.eon in messaging middleware `interceptDecryptionKeys()`

### DIFF
--- a/rolling-shutter/keyperimpl/gnosis/messagingmiddleware.go
+++ b/rolling-shutter/keyperimpl/gnosis/messagingmiddleware.go
@@ -15,7 +15,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	obskeyperdatabase "github.com/shutter-network/rolling-shutter/rolling-shutter/chainobserver/db/keyper"
-	corekeyperdatabase "github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/database"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyperimpl/gnosis/database"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyperimpl/gnosis/gnosisssztypes"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley"
@@ -206,7 +205,6 @@ func (i *MessagingMiddleware) interceptDecryptionKeys(
 	}
 
 	gnosisDB := database.New(i.dbpool)
-	keyperCoreDB := corekeyperdatabase.New(i.dbpool)
 	obsKeyperDB := obskeyperdatabase.New(i.dbpool)
 
 	trigger, err := gnosisDB.GetCurrentDecryptionTrigger(ctx, int64(originalMsg.Eon))
@@ -220,11 +218,7 @@ func (i *MessagingMiddleware) interceptDecryptionKeys(
 		return nil, errors.Wrapf(err, "failed to get current decryption trigger for eon %d", originalMsg.Eon)
 	}
 
-	eonData, err := keyperCoreDB.GetEon(ctx, int64(originalMsg.Eon))
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get eon data from database for eon %d", originalMsg.Eon)
-	}
-	keyperSet, err := obsKeyperDB.GetKeyperSetByKeyperConfigIndex(ctx, eonData.KeyperConfigIndex)
+	keyperSet, err := obsKeyperDB.GetKeyperSetByKeyperConfigIndex(ctx, int64(originalMsg.Eon))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get keyper set from database for eon %d", originalMsg.Eon)
 	}


### PR DESCRIPTION
There was a bug in `interceptDecryptionKeys()`.

If a decryption keys message is received it gets forwarded to the network. However, before it gets forwarded some checks are done by a middleware, which checks it against the keyper's own DB.

Here we check len(slotDecryptionSignatures) which is contained in the DB against the threshold. However we fetched the wrong keyperset and got the wrong threshold. Therefore we forwarded a decryption key message with having not enough signatures in the DB. 
This bug was triggered when we received a decrpytion key message but not enough key shares yet. 


In turn, I'd like to ask you if the observation is correct:

From the code it is clear to see that we would only forward a received decryption key message if we have seen enough key shares since we check it against the signatures in the DB. 
Currently it's not clear to me if gossiping messages also run through the interceptor. Otherwise it's unclear to me how the changed code piece is actually called.
I also noticed that the gnosis extra field is being set by the interceptor. Is this intended behavior? 