### PR TITLE
Don't err on duplicate slot decryption signatures

### DIFF
--- a/rolling-shutter/keyperimpl/gnosis/database/gnosiskeyper.sqlc.gen.go
+++ b/rolling-shutter/keyperimpl/gnosis/database/gnosiskeyper.sqlc.gen.go
@@ -243,6 +243,7 @@ func (q *Queries) InitTxPointer(ctx context.Context, arg InitTxPointerParams) er
 const insertSlotDecryptionSignature = `-- name: InsertSlotDecryptionSignature :exec
 INSERT INTO slot_decryption_signatures (eon, slot, keyper_index, tx_pointer, identities_hash, signature)
 VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT DO NOTHING
 `
 
 type InsertSlotDecryptionSignatureParams struct {

--- a/rolling-shutter/keyperimpl/gnosis/database/sql/queries/gnosiskeyper.sql
+++ b/rolling-shutter/keyperimpl/gnosis/database/sql/queries/gnosiskeyper.sql
@@ -75,7 +75,8 @@ WHERE eon = $1;
 
 -- name: InsertSlotDecryptionSignature :exec
 INSERT INTO slot_decryption_signatures (eon, slot, keyper_index, tx_pointer, identities_hash, signature)
-VALUES ($1, $2, $3, $4, $5, $6);
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT DO NOTHING;
 
 -- name: GetSlotDecryptionSignatures :many
 SELECT * FROM slot_decryption_signatures


### PR DESCRIPTION
We might receive duplicate slot decryption signatures (e.g. if a key shares message is delivered multiple times, or if we receive a keys message if we've already seen a few of the corresponding shares messages). Don't log and error if we try to insert these signatures into the database.