### PR TITLE
libp2p peer metrics

### DIFF
--- a/rolling-shutter/cmd/shversion/shversion.go
+++ b/rolling-shutter/cmd/shversion/shversion.go
@@ -8,7 +8,7 @@ import (
 	"runtime/debug"
 )
 
-// This gets set via ldflags when building via the Makefile
+// This gets set via ldflags when building via the Makefile.
 var version string
 
 // Version returns shuttermint's version string.

--- a/rolling-shutter/keyper/epochkghandler/key.go
+++ b/rolling-shutter/keyper/epochkghandler/key.go
@@ -86,7 +86,12 @@ func (handler *DecryptionKeyHandler) ValidateMessage(ctx context.Context, msg p2
 	return validationResult, err
 }
 
-func checkKeysErrors(ctx context.Context, decryptionKeys *p2pmsg.DecryptionKeys, pureDKGResult *puredkg.Result, queries *database.Queries) (pubsub.ValidationResult, error) {
+func checkKeysErrors(
+	ctx context.Context,
+	decryptionKeys *p2pmsg.DecryptionKeys,
+	pureDKGResult *puredkg.Result,
+	queries *database.Queries,
+) (pubsub.ValidationResult, error) {
 	for i, k := range decryptionKeys.Keys {
 		epochSecretKey, err := k.GetEpochSecretKey()
 		if err != nil {

--- a/rolling-shutter/p2p/dht.go
+++ b/rolling-shutter/p2p/dht.go
@@ -87,6 +87,7 @@ func findPeers(ctx context.Context, h host.Host, d discovery.Discoverer, ns stri
 			newConnections := 0
 			failedDials := 0
 			for _, p := range peers {
+				collectPeerAddresses(p)
 				if p.ID == h.ID() {
 					continue
 				}

--- a/rolling-shutter/p2p/dht.go
+++ b/rolling-shutter/p2p/dht.go
@@ -76,6 +76,7 @@ func findPeers(ctx context.Context, h host.Host, d discovery.Discoverer, ns stri
 		case <-ticker.C:
 			peersBefore := len(h.Network().Peers())
 			if peersBefore >= peerTarget {
+				log.Debug().Int("peers-before", peersBefore).Int("peer-target", peerTarget).Msg("have enough peers")
 				continue
 			}
 

--- a/rolling-shutter/p2p/dht.go
+++ b/rolling-shutter/p2p/dht.go
@@ -94,6 +94,10 @@ func findPeers(ctx context.Context, h host.Host, d discovery.Discoverer, ns stri
 					continue
 				}
 				metricsP2PPeerConnectedness.WithLabelValues(ourId, p.ID.String()).Add(float64(h.Network().Connectedness(p.ID)))
+				peerPing := h.Peerstore().LatencyEWMA(p.ID)
+				if peerPing != 0 {
+					metricsP2PPeerPing.WithLabelValues(ourId, p.ID.String()).Set(peerPing.Seconds())
+				}
 				if h.Network().Connectedness(p.ID) != network.Connected {
 					_, err = h.Network().DialPeer(ctx, p.ID)
 					if err != nil {

--- a/rolling-shutter/p2p/dht.go
+++ b/rolling-shutter/p2p/dht.go
@@ -92,6 +92,7 @@ func findPeers(ctx context.Context, h host.Host, d discovery.Discoverer, ns stri
 				if p.ID == h.ID() {
 					continue
 				}
+				metricsP2PPeerConnectedness.WithLabelValues(p.ID.String()).Add(float64(h.Network().Connectedness(p.ID)))
 				if h.Network().Connectedness(p.ID) != network.Connected {
 					_, err = h.Network().DialPeer(ctx, p.ID)
 					if err != nil {

--- a/rolling-shutter/p2p/dht.go
+++ b/rolling-shutter/p2p/dht.go
@@ -87,12 +87,13 @@ func findPeers(ctx context.Context, h host.Host, d discovery.Discoverer, ns stri
 
 			newConnections := 0
 			failedDials := 0
+			ourId := h.ID().String()
 			for _, p := range peers {
 				collectPeerAddresses(p)
 				if p.ID == h.ID() {
 					continue
 				}
-				metricsP2PPeerConnectedness.WithLabelValues(p.ID.String()).Add(float64(h.Network().Connectedness(p.ID)))
+				metricsP2PPeerConnectedness.WithLabelValues(ourId, p.ID.String()).Add(float64(h.Network().Connectedness(p.ID)))
 				if h.Network().Connectedness(p.ID) != network.Connected {
 					_, err = h.Network().DialPeer(ctx, p.ID)
 					if err != nil {

--- a/rolling-shutter/p2p/metrics.go
+++ b/rolling-shutter/p2p/metrics.go
@@ -31,7 +31,7 @@ var metricsP2PPeerTuples = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Namespace: "shutter",
 		Subsystem: "p2p",
-		Name:      "peer_candidate",
+		Name:      "peer_candidate_info",
 		Help:      "Collection of the encountered peer tuples.",
 	},
 	[]string{"peer_id", "peer_ip"})
@@ -43,7 +43,7 @@ var metricsP2PPeerConnectedness = prometheus.NewGaugeVec(
 		Name:      "peer_connectedness",
 		Help:      "Collection of the connectedness (0=NotConnected; 1=Connected; 2=CanConnect; 3=CannotConnect) to a peer ID.",
 	},
-	[]string{"peer_id"})
+	[]string{"our_id", "peer_id"})
 
 func collectPeerAddresses(p peer.AddrInfo) {
 	for _, multiAddr := range p.Addrs {
@@ -55,4 +55,5 @@ func init() {
 	prometheus.MustRegister(metricsP2PMessageValidationTime)
 	prometheus.MustRegister(metricsP2PMessageHandlingTime)
 	prometheus.MustRegister(metricsP2PPeerTuples)
+	prometheus.MustRegister(metricsP2PPeerConnectedness)
 }

--- a/rolling-shutter/p2p/metrics.go
+++ b/rolling-shutter/p2p/metrics.go
@@ -45,9 +45,9 @@ var metricsP2PPeerConnectedness = prometheus.NewGaugeVec(
 	},
 	[]string{"peer_id"})
 
-func collectPeerAddresses(peer peer.AddrInfo) {
-	for _, multiAddr := range peer.Addrs {
-		metricsP2PPeerTuples.WithLabelValues(peer.ID.String(), multiAddr.String()).Add(1)
+func collectPeerAddresses(p peer.AddrInfo) {
+	for _, multiAddr := range p.Addrs {
+		metricsP2PPeerTuples.WithLabelValues(p.ID.String(), multiAddr.String()).Add(1)
 	}
 }
 

--- a/rolling-shutter/p2p/metrics.go
+++ b/rolling-shutter/p2p/metrics.go
@@ -31,10 +31,19 @@ var metricsP2PPeerTuples = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Namespace: "shutter",
 		Subsystem: "p2p",
-		Name:      "dialed_peer",
-		Help:      "Collection of the encountered peer tuples",
+		Name:      "peer_candidate",
+		Help:      "Collection of the encountered peer tuples.",
 	},
 	[]string{"peer_id", "peer_ip"})
+
+var metricsP2PPeerConnectedness = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "shutter",
+		Subsystem: "p2p",
+		Name:      "peer_connectedness",
+		Help:      "Collection of the connectedness (0=NotConnected; 1=Connected; 2=CanConnect; 3=CannotConnect) to a peer ID.",
+	},
+	[]string{"peer_id"})
 
 func collectPeerAddresses(peer peer.AddrInfo) {
 	for _, multiAddr := range peer.Addrs {

--- a/rolling-shutter/p2p/metrics.go
+++ b/rolling-shutter/p2p/metrics.go
@@ -45,6 +45,16 @@ var metricsP2PPeerConnectedness = prometheus.NewGaugeVec(
 	},
 	[]string{"our_id", "peer_id"})
 
+var metricsP2PPeerPing = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "shutter",
+		Subsystem: "p2p",
+		Name:      "peer_ping_time_seconds",
+		Help:      "Collection of the ping time to a peer ID.",
+	},
+	[]string{"our_id", "peer_id"},
+)
+
 func collectPeerAddresses(p peer.AddrInfo) {
 	for _, multiAddr := range p.Addrs {
 		metricsP2PPeerTuples.WithLabelValues(p.ID.String(), multiAddr.String()).Add(1)
@@ -56,4 +66,5 @@ func init() {
 	prometheus.MustRegister(metricsP2PMessageHandlingTime)
 	prometheus.MustRegister(metricsP2PPeerTuples)
 	prometheus.MustRegister(metricsP2PPeerConnectedness)
+	prometheus.MustRegister(metricsP2PPeerPing)
 }

--- a/rolling-shutter/p2p/metrics.go
+++ b/rolling-shutter/p2p/metrics.go
@@ -1,6 +1,9 @@
 package p2p
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var metricsP2PMessageValidationTime = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
@@ -24,7 +27,23 @@ var metricsP2PMessageHandlingTime = prometheus.NewHistogramVec(
 	[]string{"topic"},
 )
 
+var metricsP2PPeerTuples = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "shutter",
+		Subsystem: "p2p",
+		Name:      "dialed_peer",
+		Help:      "Collection of the encountered peer tuples",
+	},
+	[]string{"peer_id", "peer_ip"})
+
+func collectPeerAddresses(peer peer.AddrInfo) {
+	for _, multiAddr := range peer.Addrs {
+		metricsP2PPeerTuples.WithLabelValues(peer.ID.String(), multiAddr.String()).Add(1)
+	}
+}
+
 func init() {
 	prometheus.MustRegister(metricsP2PMessageValidationTime)
 	prometheus.MustRegister(metricsP2PMessageHandlingTime)
+	prometheus.MustRegister(metricsP2PPeerTuples)
 }

--- a/rolling-shutter/p2p/p2p.go
+++ b/rolling-shutter/p2p/p2p.go
@@ -200,6 +200,7 @@ func createHost(
 		libp2p.ListenAddrs(config.ListenAddrs...),
 		libp2p.ConnectionManager(connectionManager),
 		libp2p.ProtocolVersion(protocolVersion),
+		libp2p.Ping(true),
 	}
 
 	localNetworking := bool(config.Environment == env.EnvironmentLocal)


### PR DESCRIPTION
This adds 
- a labeled collection of peers encountered in the dht as a prometheus metric.
- [the `connectedness` of a peer candidate](https://github.com/libp2p/go-libp2p/blob/abca4e693014a6c64a5c66790a742affca0700ef/core/network/network.go#L49-L64) as a prometheus metric.