### PR TITLE
Reduce block sync batch size

### DIFF
--- a/rolling-shutter/keyperimpl/gnosis/validatorsyncer.go
+++ b/rolling-shutter/keyperimpl/gnosis/validatorsyncer.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	ValidatorRegistrationMessageVersion = 0
-	maxRequestBlockRange                = 100000
+	maxRequestBlockRange                = 10_000
 )
 
 type ValidatorSyncer struct {


### PR DESCRIPTION
Up until now we used a batch size of 100,000 blocks when back syncing blocks. This caused issues with timouts in some cases and on some execution clients while performing `eth_getLogs` calls.

This now changes the max batch size to 10,000.