### PR TITLE
updated sync monitor to not throw error when dkg is happening

### DIFF
--- a/rolling-shutter/keyperimpl/shutterservice/keyper.go
+++ b/rolling-shutter/keyperimpl/shutterservice/keyper.go
@@ -114,9 +114,8 @@ func (kpr *Keyper) Start(ctx context.Context, runner service.Runner) error {
 	}
 
 	kpr.syncMonitor = &SyncMonitor{
-		DBPool:             kpr.dbpool,
-		CheckInterval:      time.Duration(kpr.config.Chain.SyncMonitorCheckInterval) * time.Second,
-		DKGStartBlockDelta: kpr.config.Shuttermint.DKGStartBlockDelta,
+		DBPool:        kpr.dbpool,
+		CheckInterval: time.Duration(kpr.config.Chain.SyncMonitorCheckInterval) * time.Second,
 	}
 	runner.Go(func() error { return kpr.processInputs(ctx) })
 	return runner.StartService(kpr.core, kpr.chainSyncClient, kpr.eonKeyPublisher, kpr.syncMonitor)

--- a/rolling-shutter/keyperimpl/shutterservice/keyper.go
+++ b/rolling-shutter/keyperimpl/shutterservice/keyper.go
@@ -114,8 +114,9 @@ func (kpr *Keyper) Start(ctx context.Context, runner service.Runner) error {
 	}
 
 	kpr.syncMonitor = &SyncMonitor{
-		DBPool:        kpr.dbpool,
-		CheckInterval: time.Duration(kpr.config.Chain.SyncMonitorCheckInterval) * time.Second,
+		DBPool:             kpr.dbpool,
+		CheckInterval:      time.Duration(kpr.config.Chain.SyncMonitorCheckInterval) * time.Second,
+		DKGStartBlockDelta: kpr.config.Shuttermint.DKGStartBlockDelta,
 	}
 	runner.Go(func() error { return kpr.processInputs(ctx) })
 	return runner.StartService(kpr.core, kpr.chainSyncClient, kpr.eonKeyPublisher, kpr.syncMonitor)

--- a/rolling-shutter/keyperimpl/shutterservice/metrics.go
+++ b/rolling-shutter/keyperimpl/shutterservice/metrics.go
@@ -1,0 +1,16 @@
+package shutterservice
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var metricsRegistryEventsSyncedUntil = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: "shutter",
+		Subsystem: "shutter_api",
+		Name:      "registry_events_syned_until",
+		Help:      "Current value of the latest block fetched",
+	},
+)
+
+func init() {
+	prometheus.MustRegister(metricsRegistryEventsSyncedUntil)
+}

--- a/rolling-shutter/keyperimpl/shutterservice/registrysyncer.go
+++ b/rolling-shutter/keyperimpl/shutterservice/registrysyncer.go
@@ -182,6 +182,8 @@ func (s *RegistrySyncer) syncRange(
 		Int("num-inserted-events", len(filteredEvents)).
 		Int("num-discarded-events", len(events)-len(filteredEvents)).
 		Msg("synced registry contract")
+
+	metricsRegistryEventsSyncedUntil.Set(float64(end))
 	return nil
 }
 

--- a/rolling-shutter/keyperimpl/shutterservice/syncmonitor_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/syncmonitor_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v4/pgxpool"
 	"gotest.tools/assert"
 
-	"github.com/jackc/pgx/v4/pgxpool"
 	keyperDB "github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/database"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyperimpl/shutterservice"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyperimpl/shutterservice/database"
@@ -16,6 +16,7 @@ import (
 )
 
 func setupTestData(ctx context.Context, t *testing.T, dbpool *pgxpool.Pool, blockNumber int64) {
+	t.Helper()
 	db := database.New(dbpool)
 	keyperdb := keyperDB.New(dbpool)
 

--- a/rolling-shutter/keyperimpl/shutterservice/syncmonitor_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/syncmonitor_test.go
@@ -7,11 +7,39 @@ import (
 
 	"gotest.tools/assert"
 
+	"github.com/jackc/pgx/v4/pgxpool"
+	keyperDB "github.com/shutter-network/rolling-shutter/rolling-shutter/keyper/database"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyperimpl/shutterservice"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyperimpl/shutterservice/database"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/service"
 	"github.com/shutter-network/rolling-shutter/rolling-shutter/medley/testsetup"
 )
+
+func setupTestData(ctx context.Context, t *testing.T, dbpool *pgxpool.Pool, blockNumber int64) {
+	db := database.New(dbpool)
+	keyperdb := keyperDB.New(dbpool)
+
+	// Set up batch config
+	err := keyperdb.InsertBatchConfig(ctx, keyperDB.InsertBatchConfigParams{
+		KeyperConfigIndex: 1,
+		Keypers:           []string{},
+	})
+	assert.NilError(t, err)
+
+	// Set up DKG result
+	err = keyperdb.InsertDKGResult(ctx, keyperDB.InsertDKGResultParams{
+		Eon:     1,
+		Success: true,
+	})
+	assert.NilError(t, err)
+
+	// Set up initial block
+	err = db.SetIdentityRegisteredEventSyncedUntil(ctx, database.SetIdentityRegisteredEventSyncedUntilParams{
+		BlockHash:   []byte{0x01, 0x02, 0x03},
+		BlockNumber: blockNumber,
+	})
+	assert.NilError(t, err)
+}
 
 func TestAPISyncMonitor_ThrowsErrorWhenBlockNotIncreasing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -19,17 +47,9 @@ func TestAPISyncMonitor_ThrowsErrorWhenBlockNotIncreasing(t *testing.T) {
 
 	dbpool, dbclose := testsetup.NewTestDBPool(ctx, t, database.Definition)
 	defer dbclose()
-	db := database.New(dbpool)
 
 	initialBlockNumber := int64(100)
-
-	err := db.SetIdentityRegisteredEventSyncedUntil(ctx, database.SetIdentityRegisteredEventSyncedUntilParams{
-		BlockHash:   []byte{0x01, 0x02, 0x03},
-		BlockNumber: initialBlockNumber,
-	})
-	if err != nil {
-		t.Fatalf("failed to set initial synced data: %v", err)
-	}
+	setupTestData(ctx, t, dbpool, initialBlockNumber)
 
 	monitor := &shutterservice.SyncMonitor{
 		DBPool:        dbpool,
@@ -37,7 +57,6 @@ func TestAPISyncMonitor_ThrowsErrorWhenBlockNotIncreasing(t *testing.T) {
 	}
 
 	errCh := make(chan error, 1)
-
 	go func() {
 		err := service.RunWithSighandler(ctx, monitor)
 		if err != nil {
@@ -49,7 +68,7 @@ func TestAPISyncMonitor_ThrowsErrorWhenBlockNotIncreasing(t *testing.T) {
 
 	select {
 	case err := <-errCh:
-		assert.ErrorContains(t, err, "block number has not increased between checks")
+		assert.ErrorContains(t, err, shutterservice.ErrBlockNotIncreasing.Error())
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected an error, but none was returned")
 	}
@@ -64,13 +83,7 @@ func TestAPISyncMonitor_HandlesBlockNumberIncreasing(t *testing.T) {
 	db := database.New(dbpool)
 
 	initialBlockNumber := int64(100)
-	err := db.SetIdentityRegisteredEventSyncedUntil(ctx, database.SetIdentityRegisteredEventSyncedUntilParams{
-		BlockHash:   []byte{0x01, 0x02, 0x03},
-		BlockNumber: initialBlockNumber,
-	})
-	if err != nil {
-		t.Fatalf("failed to set initial synced data: %v", err)
-	}
+	setupTestData(ctx, t, dbpool, initialBlockNumber)
 
 	monitor := &shutterservice.SyncMonitor{
 		DBPool:        dbpool,
@@ -114,7 +127,21 @@ func TestAPISyncMonitor_ContinuesWhenNoRows(t *testing.T) {
 
 	dbpool, closeDB := testsetup.NewTestDBPool(ctx, t, database.Definition)
 	defer closeDB()
-	_ = database.New(dbpool)
+
+	// Only set up keyper set and DKG result, but no block data
+	keyperdb := keyperDB.New(dbpool)
+
+	err := keyperdb.InsertBatchConfig(ctx, keyperDB.InsertBatchConfigParams{
+		KeyperConfigIndex: 1,
+		Keypers:           []string{},
+	})
+	assert.NilError(t, err)
+
+	err = keyperdb.InsertDKGResult(ctx, keyperDB.InsertDKGResultParams{
+		Eon:     1,
+		Success: true,
+	})
+	assert.NilError(t, err)
 
 	monitor := &shutterservice.SyncMonitor{
 		DBPool:        dbpool,
@@ -140,4 +167,110 @@ func TestAPISyncMonitor_ContinuesWhenNoRows(t *testing.T) {
 		t.Fatalf("expected monitor to continue without error, but got: %v", err)
 	case <-time.After(1 * time.Second):
 	}
+}
+
+func TestAPISyncMonitor_ContinuesWhenNoDKGResult(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbpool, closeDB := testsetup.NewTestDBPool(ctx, t, database.Definition)
+	defer closeDB()
+	db := database.New(dbpool)
+	keyperdb := keyperDB.New(dbpool)
+
+	// Set up batch config, but no DKG result
+	err := keyperdb.InsertBatchConfig(ctx, keyperDB.InsertBatchConfigParams{
+		KeyperConfigIndex: 1,
+		Keypers:           []string{},
+	})
+	assert.NilError(t, err)
+
+	// Set up initial block data
+	initialBlockNumber := int64(100)
+	err = db.SetIdentityRegisteredEventSyncedUntil(ctx, database.SetIdentityRegisteredEventSyncedUntilParams{
+		BlockHash:   []byte{0x01, 0x02, 0x03},
+		BlockNumber: initialBlockNumber,
+	})
+	assert.NilError(t, err)
+
+	monitor := &shutterservice.SyncMonitor{
+		DBPool:        dbpool,
+		CheckInterval: 5 * time.Second,
+	}
+
+	monitorCtx, cancelMonitor := context.WithCancel(ctx)
+	defer cancelMonitor()
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := service.RunWithSighandler(monitorCtx, monitor)
+		if err != nil {
+			errCh <- err
+		}
+	}()
+
+	// Let it run for a while without incrementing the block number
+	time.Sleep(15 * time.Second)
+	cancelMonitor()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("expected monitor to continue without error, but got: %v", err)
+	case <-time.After(1 * time.Second):
+		// Test passes if no error is received
+	}
+
+	// Verify the block number hasn't changed
+	syncedData, err := db.GetIdentityRegisteredEventsSyncedUntil(ctx)
+	assert.NilError(t, err)
+	assert.Equal(t, initialBlockNumber, syncedData.BlockNumber, "block number should remain unchanged")
+}
+
+func TestAPISyncMonitor_ContinuesWhenNoBatchConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbpool, closeDB := testsetup.NewTestDBPool(ctx, t, database.Definition)
+	defer closeDB()
+	db := database.New(dbpool)
+
+	// Only set up initial block data, no keyper set
+	initialBlockNumber := int64(100)
+	err := db.SetIdentityRegisteredEventSyncedUntil(ctx, database.SetIdentityRegisteredEventSyncedUntilParams{
+		BlockHash:   []byte{0x01, 0x02, 0x03},
+		BlockNumber: initialBlockNumber,
+	})
+	assert.NilError(t, err)
+
+	monitor := &shutterservice.SyncMonitor{
+		DBPool:        dbpool,
+		CheckInterval: 5 * time.Second,
+	}
+
+	monitorCtx, cancelMonitor := context.WithCancel(ctx)
+	defer cancelMonitor()
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := service.RunWithSighandler(monitorCtx, monitor)
+		if err != nil {
+			errCh <- err
+		}
+	}()
+
+	// Let it run for a while without incrementing the block number
+	time.Sleep(15 * time.Second)
+	cancelMonitor()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("expected monitor to continue without error, but got: %v", err)
+	case <-time.After(1 * time.Second):
+		// Test passes if no error is received
+	}
+
+	// Verify the block number hasn't changed
+	syncedData, err := db.GetIdentityRegisteredEventsSyncedUntil(ctx)
+	assert.NilError(t, err)
+	assert.Equal(t, initialBlockNumber, syncedData.BlockNumber, "block number should remain unchanged")
 }

--- a/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
+++ b/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
@@ -62,7 +62,7 @@ func (s *EonPubKeySyncer) Start(ctx context.Context, runner service.Runner) erro
 	}
 	runner.Defer(subs.Unsubscribe)
 	runner.Go(func() error {
-		return s.watchNewEonPubkey(ctx, subs.Err())
+		return s.watchNewEonPubkey(ctx)
 	})
 	return nil
 }
@@ -126,7 +126,7 @@ func (s *EonPubKeySyncer) GetEonPubKeyForEon(ctx context.Context, opts *bind.Cal
 	}, nil
 }
 
-func (s *EonPubKeySyncer) watchNewEonPubkey(ctx context.Context, subsErr <-chan error) error {
+func (s *EonPubKeySyncer) watchNewEonPubkey(ctx context.Context) error {
 	for {
 		select {
 		case newEonKey, ok := <-s.keyBroadcastCh:
@@ -147,8 +147,6 @@ func (s *EonPubKeySyncer) watchNewEonPubkey(ctx context.Context, subsErr <-chan 
 					err.Error(),
 				)
 			}
-		case err := <-subsErr:
-			s.Log.Error("subscription error for watchNewEonPubkey", err.Error())
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
+++ b/rolling-shutter/medley/chainsync/syncer/eonpubkey.go
@@ -57,13 +57,12 @@ func (s *EonPubKeySyncer) Start(ctx context.Context, runner service.Runner) erro
 	}
 	s.keyBroadcastCh = make(chan *bindings.KeyBroadcastContractEonKeyBroadcast, channelSize)
 	subs, err := s.KeyBroadcast.WatchEonKeyBroadcast(watchOpts, s.keyBroadcastCh)
-	// FIXME: what to do on subs.Error()
 	if err != nil {
 		return err
 	}
 	runner.Defer(subs.Unsubscribe)
 	runner.Go(func() error {
-		return s.watchNewEonPubkey(ctx)
+		return s.watchNewEonPubkey(ctx, subs.Err())
 	})
 	return nil
 }
@@ -127,7 +126,7 @@ func (s *EonPubKeySyncer) GetEonPubKeyForEon(ctx context.Context, opts *bind.Cal
 	}, nil
 }
 
-func (s *EonPubKeySyncer) watchNewEonPubkey(ctx context.Context) error {
+func (s *EonPubKeySyncer) watchNewEonPubkey(ctx context.Context, subsErr <-chan error) error {
 	for {
 		select {
 		case newEonKey, ok := <-s.keyBroadcastCh:
@@ -148,6 +147,8 @@ func (s *EonPubKeySyncer) watchNewEonPubkey(ctx context.Context) error {
 					err.Error(),
 				)
 			}
+		case err := <-subsErr:
+			s.Log.Error("subscription error for watchNewEonPubkey", err.Error())
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/keyperset.go
+++ b/rolling-shutter/medley/chainsync/syncer/keyperset.go
@@ -72,7 +72,7 @@ func (s *KeyperSetSyncer) Start(ctx context.Context, runner service.Runner) erro
 	}
 	runner.Defer(subs.Unsubscribe)
 	runner.Go(func() error {
-		return s.watchNewKeypersService(ctx)
+		return s.watchNewKeypersService(ctx, subs.Err())
 	})
 	return nil
 }
@@ -204,7 +204,7 @@ func (s *KeyperSetSyncer) newEvent(
 	}, nil
 }
 
-func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context) error {
+func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context, subsErr <-chan error) error {
 	for {
 		select {
 		case newKeypers, ok := <-s.keyperAddedCh:
@@ -233,6 +233,10 @@ func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context) error {
 					"error",
 					err.Error(),
 				)
+			}
+		case err := <-subsErr:
+			if err != nil {
+				s.Log.Error("subscription error for watchNewKeypersService", err)
 			}
 		case <-ctx.Done():
 			return ctx.Err()

--- a/rolling-shutter/medley/chainsync/syncer/keyperset.go
+++ b/rolling-shutter/medley/chainsync/syncer/keyperset.go
@@ -72,7 +72,7 @@ func (s *KeyperSetSyncer) Start(ctx context.Context, runner service.Runner) erro
 	}
 	runner.Defer(subs.Unsubscribe)
 	runner.Go(func() error {
-		return s.watchNewKeypersService(ctx, subs.Err())
+		return s.watchNewKeypersService(ctx)
 	})
 	return nil
 }
@@ -204,7 +204,7 @@ func (s *KeyperSetSyncer) newEvent(
 	}, nil
 }
 
-func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context, subsErr <-chan error) error {
+func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context) error {
 	for {
 		select {
 		case newKeypers, ok := <-s.keyperAddedCh:
@@ -234,8 +234,6 @@ func (s *KeyperSetSyncer) watchNewKeypersService(ctx context.Context, subsErr <-
 					err.Error(),
 				)
 			}
-		case err := <-subsErr:
-			s.Log.Error("subscription error for watchNewKeypersService", err.Error())
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/shutterstate.go
+++ b/rolling-shutter/medley/chainsync/syncer/shutterstate.go
@@ -63,7 +63,7 @@ func (s *ShutterStateSyncer) Start(ctx context.Context, runner service.Runner) e
 	runner.Defer(subsUnpaused.Unsubscribe)
 
 	runner.Go(func() error {
-		return s.watchPaused(ctx, subs.Err(), subsUnpaused.Err())
+		return s.watchPaused(ctx)
 	})
 	return nil
 }
@@ -87,7 +87,7 @@ func (s *ShutterStateSyncer) handle(ctx context.Context, ev *event.ShutterState)
 	}
 }
 
-func (s *ShutterStateSyncer) watchPaused(ctx context.Context, subsErr <-chan error, subsErrUnpaused <-chan error) error {
+func (s *ShutterStateSyncer) watchPaused(ctx context.Context) error {
 	isActive, err := s.pollIsActive(ctx)
 	if err != nil {
 		// XXX: this will fail everything, do we want that?
@@ -123,10 +123,6 @@ func (s *ShutterStateSyncer) watchPaused(ctx context.Context, subsErr <-chan err
 			}
 			isActive = ev.Active
 			s.handle(ctx, ev)
-		case err := <-subsErr:
-			s.Log.Error("subscription error for watchPaused", err.Error())
-		case err := <-subsErrUnpaused:
-			s.Log.Error("subscription error for watchUnpaused", err.Error())
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/shutterstate.go
+++ b/rolling-shutter/medley/chainsync/syncer/shutterstate.go
@@ -50,22 +50,20 @@ func (s *ShutterStateSyncer) Start(ctx context.Context, runner service.Runner) e
 	}
 	s.pausedCh = make(chan *bindings.KeyperSetManagerPaused)
 	subs, err := s.Contract.WatchPaused(watchOpts, s.pausedCh)
-	// FIXME: what to do on subs.Error()
 	if err != nil {
 		return err
 	}
 	runner.Defer(subs.Unsubscribe)
 
 	s.unpausedCh = make(chan *bindings.KeyperSetManagerUnpaused)
-	subs, err = s.Contract.WatchUnpaused(watchOpts, s.unpausedCh)
-	// FIXME: what to do on subs.Error()
+	subsUnpaused, err := s.Contract.WatchUnpaused(watchOpts, s.unpausedCh)
 	if err != nil {
 		return err
 	}
-	runner.Defer(subs.Unsubscribe)
+	runner.Defer(subsUnpaused.Unsubscribe)
 
 	runner.Go(func() error {
-		return s.watchPaused(ctx)
+		return s.watchPaused(ctx, subs.Err(), subsUnpaused.Err())
 	})
 	return nil
 }
@@ -89,7 +87,7 @@ func (s *ShutterStateSyncer) handle(ctx context.Context, ev *event.ShutterState)
 	}
 }
 
-func (s *ShutterStateSyncer) watchPaused(ctx context.Context) error {
+func (s *ShutterStateSyncer) watchPaused(ctx context.Context, subsErr <-chan error, subsErrUnpaused <-chan error) error {
 	isActive, err := s.pollIsActive(ctx)
 	if err != nil {
 		// XXX: this will fail everything, do we want that?
@@ -125,6 +123,10 @@ func (s *ShutterStateSyncer) watchPaused(ctx context.Context) error {
 			}
 			isActive = ev.Active
 			s.handle(ctx, ev)
+		case err := <-subsErr:
+			s.Log.Error("subscription error for watchPaused", err.Error())
+		case err := <-subsErrUnpaused:
+			s.Log.Error("subscription error for watchUnpaused", err.Error())
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/shutterstate.go
+++ b/rolling-shutter/medley/chainsync/syncer/shutterstate.go
@@ -63,7 +63,7 @@ func (s *ShutterStateSyncer) Start(ctx context.Context, runner service.Runner) e
 	runner.Defer(subsUnpaused.Unsubscribe)
 
 	runner.Go(func() error {
-		return s.watchPaused(ctx)
+		return s.watchPaused(ctx, subs.Err(), subsUnpaused.Err())
 	})
 	return nil
 }
@@ -87,7 +87,7 @@ func (s *ShutterStateSyncer) handle(ctx context.Context, ev *event.ShutterState)
 	}
 }
 
-func (s *ShutterStateSyncer) watchPaused(ctx context.Context) error {
+func (s *ShutterStateSyncer) watchPaused(ctx context.Context, subsErr <-chan error, subsErrUnpaused <-chan error) error {
 	isActive, err := s.pollIsActive(ctx)
 	if err != nil {
 		// XXX: this will fail everything, do we want that?
@@ -123,6 +123,14 @@ func (s *ShutterStateSyncer) watchPaused(ctx context.Context) error {
 			}
 			isActive = ev.Active
 			s.handle(ctx, ev)
+		case err := <-subsErr:
+			if err != nil {
+				s.Log.Error("subscription error for watchPaused")
+			}
+		case err := <-subsErrUnpaused:
+			if err != nil {
+				s.Log.Error("subscription error for watchUnpaused", err)
+			}
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -33,12 +33,12 @@ func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) err
 	}
 	runner.Defer(subs.Unsubscribe)
 	runner.Go(func() error {
-		return s.watchLatestUnsafeHead(ctx, subs.Err())
+		return s.watchLatestUnsafeHead(ctx)
 	})
 	return nil
 }
 
-func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context, subsErr <-chan error) error {
+func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
 	for {
 		select {
 		case newHeader, ok := <-s.newLatestHeadCh:
@@ -58,8 +58,6 @@ func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context, subsErr <-
 					err.Error(),
 				)
 			}
-		case err := <-subsErr:
-			s.Log.Error("subscription error for watchLatestUnsafeHead", err.Error())
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/rolling-shutter/medley/chainsync/syncer/unsafehead.go
+++ b/rolling-shutter/medley/chainsync/syncer/unsafehead.go
@@ -33,12 +33,12 @@ func (s *UnsafeHeadSyncer) Start(ctx context.Context, runner service.Runner) err
 	}
 	runner.Defer(subs.Unsubscribe)
 	runner.Go(func() error {
-		return s.watchLatestUnsafeHead(ctx)
+		return s.watchLatestUnsafeHead(ctx, subs.Err())
 	})
 	return nil
 }
 
-func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
+func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context, subsErr <-chan error) error {
 	for {
 		select {
 		case newHeader, ok := <-s.newLatestHeadCh:
@@ -57,6 +57,10 @@ func (s *UnsafeHeadSyncer) watchLatestUnsafeHead(ctx context.Context) error {
 					"error",
 					err.Error(),
 				)
+			}
+		case err := <-subsErr:
+			if err != nil {
+				s.Log.Error("subscription error for watchLatestUnsafeHead", err)
 			}
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
- Using batch config message here to determine, latest eon and using `dkg_result` table to know if dkg was completed.
This was because, if the syncing is stalled then the `keyper_set` will not be updated in database.

- This PR also adds logging when subscription for any event fails