### PR TITLE
Complex event data

### DIFF
--- a/docs/event.md
+++ b/docs/event.md
@@ -21,7 +21,7 @@ An `EventTriggerDefinition` is a structured data object that combines:
   trigger the release of the decryption key.
 
 Reference:
-[EventTriggerDefinition Type](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L21-L25)
+[EventTriggerDefinition Type](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L21-L25)
 
 ### LogPredicate
 
@@ -29,7 +29,7 @@ A `LogPredicate` pairs a reference to a specific value within an event log with
 a predicate that must be satisfied for the trigger to fire.
 
 Reference:
-[LogPredicate Type](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L27-L32)
+[LogPredicate Type](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L27-L32)
 
 ### LogValueRef
 
@@ -44,7 +44,7 @@ It can reference:
   data offset always starts at 4, even if there are fewer than 4 topics defined.
 
 Reference:
-[LogValueRef Type and Documentation](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L34-L43)
+[LogValueRef Type and Documentation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L34-L42)
 
 ### ValuePredicate
 
@@ -53,7 +53,7 @@ log value. It consists of an operation (`Op`) and a set of arguments. The type
 and number of arguments required depend on the operation.
 
 Reference:
-[ValuePredicate Type](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L45-L53)
+[ValuePredicate Type](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L44-L52)
 
 ## Encoding Format
 
@@ -64,21 +64,21 @@ encoding with a version byte prefix:
 
 ```
 EventTriggerDefinitionBytes := {
-    version: uint8                    // Current version is 0x01
+    version: uint8                    // Current version is 0x02
     rlp_encoded_content: []byte       // RLP-encoded EventTriggerDefinition
 }
 ```
 
-The version byte (`0x01`) allows for future format changes. After the version
+The version byte (`0x02`) allows for future format changes. After the version
 byte, the remaining bytes are RLP-encoded content representing the
 `EventTriggerDefinition` structure.
 
 Reference:
-[MarshalBytes and UnmarshalBytes Implementation](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L58-L86)
+[MarshalBytes and UnmarshalBytes Implementation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L57-L85)
 
 ### Versioning
 
-The current version is **0x01** as defined by the `Version` constant.
+The current version is **0x02** as defined by the `Version` constant.
 
 ### RLP Encoding Details
 
@@ -96,8 +96,7 @@ LogPredicate := {
     valuePredicate: ValuePredicate
 }
 
-LogValueRef := Offset                    // if Length == 1
-LogValueRef := [Offset, Length]          // if Length > 1
+LogValueRef := Offset
 
 ValuePredicate := {
     op: uint64,
@@ -110,7 +109,7 @@ ValuePredicate := {
 ```
 
 Reference:
-[RLP Encoding Implementation](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L211-L392)
+[RLP Encoding Implementation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L210-L416)
 
 ## Operators
 
@@ -137,7 +136,7 @@ value predicate.
   - Returns true if value == argument (byte-by-byte comparison)
 
 Reference:
-[Operator Constants](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L298-L305)
+[Operator Constants](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L322-L329)
 
 Note, that different operators require different numbers and types of arguments:
 
@@ -153,7 +152,7 @@ Ethereum log satisfies the `EventTriggerDefinition`:
 2. The log must satisfy **all** log predicates (logical `AND` of all conditions)
 
 Reference:
-[Match Method](https://github.com/shutter-network/rolling-shutter/blob/42f562532acfc4f89f630d3de809fc4451636ab2/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L159-L176)
+[Match Method](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L160-L179)
 
 ### LogValueRef.GetValue
 
@@ -161,12 +160,13 @@ To retrieve a value from a log:
 
 - **Topics (Offset < 4)**: Returns the log's topic at index Offset as a 32-byte
   value
-- **Data (Offset >= 4)**: Extracts a slice of 32-byte words from the log's data,
-  starting at word index (Offset - 4). If the slice extends beyond the log's
-  data, it is zero-padded on the right to the expected length.
+- **Data (Offset >= 4)**: Extracts a slice from the log's data, starting at word
+  index (Offset - 4). The length of the slice is defined in the log data
+  according to the
+  [ABI event encoding spec](https://docs.soliditylang.org/en/latest/abi-spec.html).
 
 Reference:
-[GetValue Method](https://github.com/shutter-network/rolling-shutter/blob/main/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L210-L228)
+[GetValue Methods](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L244-L312)
 
 ## Generating EventTriggerDefinition from EVM Contract ABI
 
@@ -214,16 +214,13 @@ function generateEventTriggerDefinition(
         if (param.indexed) {
             // Topics are at offsets 0-3
             offset = calculateTopicIndex(event, param)
-            length = 1
         } else {
             // Data starts at offset 4
             offset = 4 + calculateDataWordOffset(event, param)
-            length = calculateDataWordLength(param.type)
         }
 
         logValueRef = LogValueRef{
             Offset: offset,
-            Length: length
         }
 
         // Create the ValuePredicate
@@ -302,8 +299,7 @@ Trigger when a specific address transfers tokens:
   "logPredicates": [
     {
       "logValueRef": {
-        "offset": 1,
-        "length": 1
+        "offset": 1
       },
       "valuePredicate": {
         "op": 5,
@@ -349,8 +345,7 @@ Trigger when a swap occurs with minimum token amount:
   "logPredicates": [
     {
       "logValueRef": {
-        "offset": 1,
-        "length": 1
+        "offset": 1
       },
       "valuePredicate": {
         "op": 5,
@@ -362,8 +357,7 @@ Trigger when a swap occurs with minimum token amount:
     },
     {
       "logValueRef": {
-        "offset": 5,
-        "length": 1
+        "offset": 5
       },
       "valuePredicate": {
         "op": 4,
@@ -374,3 +368,7 @@ Trigger when a swap occurs with minimum token amount:
   ]
 }
 ```
+
+Note: an example for an event trigger definition compiler can be found in
+[shutter-api](https://github.com/shutter-network/shutter-api) (the
+`/event/compile_event_trigger_definition` endpoint.)

--- a/docs/event.md
+++ b/docs/event.md
@@ -39,12 +39,21 @@ It can reference:
 - **Topics (Offsets 0-3)**: The indexed parameters of the event log. A topic is
   referenced by its index (0-3), where offset 0 is topic[0], etc.
 - **Data (Offsets 4+)**: The non-indexed data section of the log. Offset
-  values >= 4 refer to 32-byte words in the log data, where offset 4 is the
-  first word (bytes 0-31), offset 5 is the second word (bytes 32-63), etc. Note:
-  data offset always starts at 4, even if there are fewer than 4 topics defined.
+  values >= 4 refer to slices in the log data, where offset 4 is the first ABI
+  encoded slice, offset 5 is the second such slice, etc.
+
+- The `Dynamic` attribute defines whether data at the offset position should be
+  read as a single 32 byte word, or, if the offset should be interpreted as an
+  [ABI encoding of a data slice](https://docs.soliditylang.org/en/latest/abi-spec.html),
+  where
+  - `internal_offset_in_bytes = uint64(WORD@Offset)` => `IOIB`
+  - `length = uint64(WORD@IOIB)`
+  - `dataslice = data[IOIB + 32 : IOIB + 32 + length]`
+- Note: data offset always starts at 4, even if there are fewer than 4 topics
+  defined.
 
 Reference:
-[LogValueRef Type and Documentation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L34-L42)
+[LogValueRef Type and Documentation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L34-L43)
 
 ### ValuePredicate
 
@@ -53,7 +62,7 @@ log value. It consists of an operation (`Op`) and a set of arguments. The type
 and number of arguments required depend on the operation.
 
 Reference:
-[ValuePredicate Type](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L44-L52)
+[ValuePredicate Type](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L45-L53)
 
 ## Encoding Format
 
@@ -74,7 +83,7 @@ byte, the remaining bytes are RLP-encoded content representing the
 `EventTriggerDefinition` structure.
 
 Reference:
-[MarshalBytes and UnmarshalBytes Implementation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L57-L85)
+[MarshalBytes and UnmarshalBytes Implementation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L58-L86)
 
 ### Versioning
 
@@ -96,7 +105,7 @@ LogPredicate := {
     valuePredicate: ValuePredicate
 }
 
-LogValueRef := Offset
+LogValueRef := {Dynamic, Offset}
 
 ValuePredicate := {
     op: uint64,
@@ -105,11 +114,11 @@ ValuePredicate := {
 }
 
 # actual dense format is more akin to this:
-[contract_address, [[offset, [op, [int_args], [byte_args]]], […]]]
+[contract_address, [[dynamic, offset, [op, [int_args], [byte_args]]], […]]]
 ```
 
 Reference:
-[RLP Encoding Implementation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L210-L416)
+[RLP Encoding Implementation](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L208-L414)
 
 ## Operators
 
@@ -136,7 +145,7 @@ value predicate.
   - Returns true if value == argument (byte-by-byte comparison)
 
 Reference:
-[Operator Constants](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L322-L329)
+[Operator Constants](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L320-L327)
 
 Note, that different operators require different numbers and types of arguments:
 
@@ -152,7 +161,7 @@ Ethereum log satisfies the `EventTriggerDefinition`:
 2. The log must satisfy **all** log predicates (logical `AND` of all conditions)
 
 Reference:
-[Match Method](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L160-L179)
+[Match Method](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L161-L179)
 
 ### LogValueRef.GetValue
 
@@ -166,7 +175,7 @@ To retrieve a value from a log:
   [ABI event encoding spec](https://docs.soliditylang.org/en/latest/abi-spec.html).
 
 Reference:
-[GetValue Methods](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L244-L312)
+[GetValue Methods](https://github.com/shutter-network/rolling-shutter/blob/7b3013978b997dc7507656851c792012f6836241/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go#L246-L318)
 
 ## Generating EventTriggerDefinition from EVM Contract ABI
 
@@ -219,7 +228,10 @@ function generateEventTriggerDefinition(
             offset = 4 + calculateDataWordOffset(event, param)
         }
 
+        dynamic = decide_if_dynamic_type(param.type)
+
         logValueRef = LogValueRef{
+            Dynamic: dynamic,
             Offset: offset,
         }
 
@@ -266,6 +278,10 @@ Non-indexed parameters are stored in the log's data field. They are packed as
 
 For types smaller than 32 bytes, they are right-padded (for fixed-size types) or
 stored in a single word.
+
+However, for `Dynamic` types, the words only specify an internal offset to
+another word that encodes the data slices length. The actual data will be at
+`internal_offset + 32` and be `length` bytes long.
 
 ## Examples
 

--- a/rolling-shutter/go.mod
+++ b/rolling-shutter/go.mod
@@ -60,7 +60,9 @@ require (
 )
 
 require (
+	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/VictoriaMetrics/fastcache v1.12.2 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
@@ -68,12 +70,19 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cockroachdb/errors v1.11.3 // indirect
+	github.com/cockroachdb/fifo v0.0.0-20240616162244-4768e80dfb9a // indirect
+	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
+	github.com/cockroachdb/pebble v1.1.2 // indirect
+	github.com/cockroachdb/redact v1.1.5 // indirect
+	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/consensys/bavard v0.1.27 // indirect
 	github.com/consensys/gnark-crypto v0.16.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/gogoproto v1.4.1 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/crate-crypto/go-eth-kzg v1.3.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
 	github.com/creachadair/taskgroup v0.3.2 // indirect
@@ -92,6 +101,7 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
+	github.com/getsentry/sentry-go v0.28.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -103,7 +113,9 @@ require (
 	github.com/go-openapi/swag v0.22.4 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.0.1 // indirect
@@ -119,6 +131,8 @@ require (
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 // indirect
+	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -158,12 +172,14 @@ require (
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/miekg/dns v1.1.66 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/mimoo/StrobeGo v0.0.0-20210601165009-122bf33a46e0 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/mitchellh/pointerstructure v1.2.1 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
@@ -176,6 +192,7 @@ require (
 	github.com/multiformats/go-multistream v0.6.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onsi/ginkgo/v2 v2.22.2 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
@@ -195,6 +212,7 @@ require (
 	github.com/pion/sdp/v3 v3.0.10 // indirect
 	github.com/pion/srtp/v3 v3.0.4 // indirect
 	github.com/pion/stun v0.6.1 // indirect
+	github.com/pion/stun/v2 v2.0.0 // indirect
 	github.com/pion/stun/v3 v3.0.0 // indirect
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pion/transport/v3 v3.0.7 // indirect
@@ -210,8 +228,10 @@ require (
 	github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rs/cors v1.9.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
@@ -222,8 +242,10 @@ require (
 	github.com/tendermint/tm-db v0.6.7 // indirect
 	github.com/tklauser/go-sysconf v0.3.13 // indirect
 	github.com/tklauser/numcpus v0.7.0 // indirect
+	github.com/urfave/cli/v2 v2.27.5 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.etcd.io/bbolt v1.3.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
@@ -238,11 +260,13 @@ require (
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
 	gonum.org/v1/gonum v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9 // indirect
 	google.golang.org/grpc v1.67.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect

--- a/rolling-shutter/go.sum
+++ b/rolling-shutter/go.sum
@@ -67,6 +67,8 @@ github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrd
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/adlio/schema v1.3.3 h1:oBJn8I02PyTB466pZO1UZEn1TV5XLlifBSyMrmHl/1I=
 github.com/adlio/schema v1.3.3/go.mod h1:1EsRssiv9/Ce2CMzq5DoL7RiMshhuigQxrR4DMV9fHg=
+github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
+github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
@@ -96,6 +98,7 @@ github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -108,6 +111,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
+github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f h1:otljaYPt5hWxV3MUfO5dFPFiOXg9CyG5/kCfayTqsJ4=
+github.com/cockroachdb/datadriven v1.0.3-0.20230413201302-be42291fc80f/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
 github.com/cockroachdb/errors v1.11.3 h1:5bA+k2Y6r+oz/6Z/RFlNeVCesGARKuC6YymtcDrbC/I=
 github.com/cockroachdb/errors v1.11.3/go.mod h1:m4UIW4CDjx+R5cybPsNrRbreomiFqt8o1h1wUVazSd8=
 github.com/cockroachdb/fifo v0.0.0-20240616162244-4768e80dfb9a h1:f52TdbU4D5nozMAhO9TvTJ2ZMCXtN4VIAmfrrZ0JXQ4=
@@ -145,7 +150,6 @@ github.com/cosmos/gogoproto v1.4.1 h1:WoyH+0/jbCTzpKNvyav5FL1ZTWsp1im1MxEpJEzKUB
 github.com/cosmos/gogoproto v1.4.1/go.mod h1:Ac9lzL4vFpBMcptJROQ6dQ4M3pOEK5Z/l0Q9p+LoCr4=
 github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -247,6 +251,8 @@ github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJ
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
 github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -299,7 +305,6 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
 github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -633,6 +638,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -746,6 +752,8 @@ github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssy
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/petermattis/goid v0.0.0-20230808133559-b036b712a89b h1:vab8deKC4QoIfm9fJM59iuNz1ELGsuLoYYpiF+pHiG8=
 github.com/petermattis/goid v0.0.0-20230808133559-b036b712a89b/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pion/datachannel v1.5.10 h1:ly0Q26K1i6ZkGf42W7D4hQYR90pZwzFOjTq5AuCKk4o=
 github.com/pion/datachannel v1.5.10/go.mod h1:p/jJfC9arb29W7WrxyKbepTU20CFgyx5oLo8Rs4Py/M=
 github.com/pion/dtls/v2 v2.2.7/go.mod h1:8WiMkebSHFD0T+dIU+UeBaoV7kDhOW5oDCzZ7WZ/F9s=
@@ -784,6 +792,7 @@ github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1A
 github.com/pion/transport/v2 v2.2.4/go.mod h1:q2U/tf9FEfnSBGSW6w5Qp5PFWRLRj3NjLhCCgpRK4p0=
 github.com/pion/transport/v2 v2.2.10 h1:ucLBLE8nuxiHfvkFKnkDQRYWYfp8ejf4YBOPfaQpw6Q=
 github.com/pion/transport/v2 v2.2.10/go.mod h1:sq1kSLWs+cHW9E+2fJP95QudkzbK7wscs8yYgQToO5E=
+github.com/pion/transport/v3 v3.0.1/go.mod h1:UY7kiITrlMv7/IKgd5eTUcaahZx5oUN3l9SzK5f5xE0=
 github.com/pion/transport/v3 v3.0.7 h1:iRbMH05BzSNwhILHoBoAPxoB9xQgOaJk+591KC9P1o0=
 github.com/pion/transport/v3 v3.0.7/go.mod h1:YleKiTZ4vqNxVwh77Z0zytYi7rXHl7j6uPLGhhz9rwo=
 github.com/pion/turn/v4 v4.0.0 h1:qxplo3Rxa9Yg1xXDxxH8xaqcyGUtbHYw4QSCvmFWvhM=
@@ -825,6 +834,7 @@ github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtB
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -841,7 +851,6 @@ github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OK
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
 github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -967,7 +976,6 @@ github.com/ulope/jrpc2 v0.0.0-20230706135348-a95cf3d96bd2/go.mod h1:bzOCUO4YLqjP
 github.com/umbracle/gohashtree v0.0.2-alpha.0.20230207094856-5b775a815c10 h1:CQh33pStIp/E30b7TxDlXfM0145bn2e8boI30IxAhTg=
 github.com/umbracle/gohashtree v0.0.2-alpha.0.20230207094856-5b775a815c10/go.mod h1:x/Pa0FF5Te9kdrlZKJK82YmAkvL8+f989USgz6Jiw7M=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.10 h1:p8Fspmz3iTctJstry1PYS3HVdllxnEzTEsgIgtxTrCk=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
@@ -1261,6 +1269,7 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/rolling-shutter/keyperimpl/shutterservice/Emitter.go
+++ b/rolling-shutter/keyperimpl/shutterservice/Emitter.go
@@ -1,0 +1,916 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package shutterservice
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// EmitterMetaData contains all meta data concerning the Emitter contract.
+var EmitterMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"five\",\"type\":\"bytes\"}],\"name\":\"Five\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"}],\"name\":\"Four\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"two\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"three\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"five\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"six\",\"type\":\"bytes\"}],\"name\":\"Six\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"newValue\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Two\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"five\",\"type\":\"bytes\"}],\"name\":\"emitFive\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"}],\"name\":\"emitFour\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"two\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"three\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"five\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"six\",\"type\":\"bytes\"}],\"name\":\"emitSix\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"emitTwo\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x608060405234801561001057600080fd5b506108ed806100206000396000f3fe608060405234801561001057600080fd5b506004361061004c5760003560e01c80636995a2d9146100515780637155880d1461006d5780638cc5e89214610089578063f70770e0146100a5575b600080fd5b61006b60048036038101906100669190610381565b6100c1565b005b61008760048036038101906100829190610434565b610104565b005b6100a3600480360381019061009e9190610461565b610140565b005b6100bf60048036038101906100ba91906105e3565b610180565b005b8284867f2778059b9d45e2cd0df03a27bbe3e688dfc48aa15a729c42f39dcd986ebd446185856040516100f592919061074c565b60405180910390a45050505050565b807fce34f015a0e20f2b0daf980b28ed50729e87b993e4d30cca4c3f4da05acbd0ac600560405161013591906107c8565b60405180910390a250565b8183857fd82c9bd67140e94b50e0a62e800c51428267b0cd733573daaafad26b62c05afb8460405161017291906107e3565b60405180910390a450505050565b8373ffffffffffffffffffffffffffffffffffffffff16856040516101a5919061084c565b6040518091039020877f1c49d7caedaa8e8be0f2ef7b3c285ccaef7eac5a7fe6b427cbe7e7d8ad3070548686866040516101e193929190610872565b60405180910390a4505050505050565b6000604051905090565b600080fd5b600080fd5b6000819050919050565b61021881610205565b811461022357600080fd5b50565b6000813590506102358161020f565b92915050565b600080fd5b600080fd5b6000601f19601f8301169050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b61028e82610245565b810181811067ffffffffffffffff821117156102ad576102ac610256565b5b80604052505050565b60006102c06101f1565b90506102cc8282610285565b919050565b600067ffffffffffffffff8211156102ec576102eb610256565b5b6102f582610245565b9050602081019050919050565b82818337600083830152505050565b600061032461031f846102d1565b6102b6565b9050828152602081018484840111156103405761033f610240565b5b61034b848285610302565b509392505050565b600082601f8301126103685761036761023b565b5b8135610378848260208601610311565b91505092915050565b600080600080600060a0868803121561039d5761039c6101fb565b5b60006103ab88828901610226565b95505060206103bc88828901610226565b94505060406103cd88828901610226565b935050606086013567ffffffffffffffff8111156103ee576103ed610200565b5b6103fa88828901610353565b925050608086013567ffffffffffffffff81111561041b5761041a610200565b5b61042788828901610353565b9150509295509295909350565b60006020828403121561044a576104496101fb565b5b600061045884828501610226565b91505092915050565b6000806000806080858703121561047b5761047a6101fb565b5b600061048987828801610226565b945050602061049a87828801610226565b93505060406104ab87828801610226565b925050606085013567ffffffffffffffff8111156104cc576104cb610200565b5b6104d887828801610353565b91505092959194509250565b600067ffffffffffffffff8211156104ff576104fe610256565b5b61050882610245565b9050602081019050919050565b6000610528610523846104e4565b6102b6565b90508281526020810184848401111561054457610543610240565b5b61054f848285610302565b509392505050565b600082601f83011261056c5761056b61023b565b5b813561057c848260208601610515565b91505092915050565b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b60006105b082610585565b9050919050565b6105c0816105a5565b81146105cb57600080fd5b50565b6000813590506105dd816105b7565b92915050565b60008060008060008060c08789031215610600576105ff6101fb565b5b600061060e89828a01610226565b965050602087013567ffffffffffffffff81111561062f5761062e610200565b5b61063b89828a01610557565b955050604061064c89828a016105ce565b945050606087013567ffffffffffffffff81111561066d5761066c610200565b5b61067989828a01610353565b935050608061068a89828a01610226565b92505060a087013567ffffffffffffffff8111156106ab576106aa610200565b5b6106b789828a01610353565b9150509295509295509295565b600081519050919050565b600082825260208201905092915050565b60005b838110156106fe5780820151818401526020810190506106e3565b8381111561070d576000848401525b50505050565b600061071e826106c4565b61072881856106cf565b93506107388185602086016106e0565b61074181610245565b840191505092915050565b600060408201905081810360008301526107668185610713565b9050818103602083015261077a8184610713565b90509392505050565b6000819050919050565b6000819050919050565b60006107b26107ad6107a884610783565b61078d565b610205565b9050919050565b6107c281610797565b82525050565b60006020820190506107dd60008301846107b9565b92915050565b600060208201905081810360008301526107fd8184610713565b905092915050565b600081519050919050565b600081905092915050565b600061082682610805565b6108308185610810565b93506108408185602086016106e0565b80840191505092915050565b6000610858828461081b565b915081905092915050565b61086c81610205565b82525050565b6000606082019050818103600083015261088c8186610713565b905061089b6020830185610863565b81810360408301526108ad8184610713565b905094935050505056fea2646970667358221220848f06dbefbfd7023244910f585f43334b07207284d4f6541eb16b4b0073fa8964736f6c63430008090033",
+}
+
+// EmitterABI is the input ABI used to generate the binding from.
+// Deprecated: Use EmitterMetaData.ABI instead.
+var EmitterABI = EmitterMetaData.ABI
+
+// EmitterBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use EmitterMetaData.Bin instead.
+var EmitterBin = EmitterMetaData.Bin
+
+// DeployEmitter deploys a new Ethereum contract, binding an instance of Emitter to it.
+func DeployEmitter(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Emitter, error) {
+	parsed, err := EmitterMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(EmitterBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Emitter{EmitterCaller: EmitterCaller{contract: contract}, EmitterTransactor: EmitterTransactor{contract: contract}, EmitterFilterer: EmitterFilterer{contract: contract}}, nil
+}
+
+// Emitter is an auto generated Go binding around an Ethereum contract.
+type Emitter struct {
+	EmitterCaller     // Read-only binding to the contract
+	EmitterTransactor // Write-only binding to the contract
+	EmitterFilterer   // Log filterer for contract events
+}
+
+// EmitterCaller is an auto generated read-only Go binding around an Ethereum contract.
+type EmitterCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EmitterTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type EmitterTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EmitterFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type EmitterFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EmitterSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type EmitterSession struct {
+	Contract     *Emitter          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// EmitterCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type EmitterCallerSession struct {
+	Contract *EmitterCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// EmitterTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type EmitterTransactorSession struct {
+	Contract     *EmitterTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// EmitterRaw is an auto generated low-level Go binding around an Ethereum contract.
+type EmitterRaw struct {
+	Contract *Emitter // Generic contract binding to access the raw methods on
+}
+
+// EmitterCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type EmitterCallerRaw struct {
+	Contract *EmitterCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// EmitterTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type EmitterTransactorRaw struct {
+	Contract *EmitterTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewEmitter creates a new instance of Emitter, bound to a specific deployed contract.
+func NewEmitter(address common.Address, backend bind.ContractBackend) (*Emitter, error) {
+	contract, err := bindEmitter(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Emitter{EmitterCaller: EmitterCaller{contract: contract}, EmitterTransactor: EmitterTransactor{contract: contract}, EmitterFilterer: EmitterFilterer{contract: contract}}, nil
+}
+
+// NewEmitterCaller creates a new read-only instance of Emitter, bound to a specific deployed contract.
+func NewEmitterCaller(address common.Address, caller bind.ContractCaller) (*EmitterCaller, error) {
+	contract, err := bindEmitter(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterCaller{contract: contract}, nil
+}
+
+// NewEmitterTransactor creates a new write-only instance of Emitter, bound to a specific deployed contract.
+func NewEmitterTransactor(address common.Address, transactor bind.ContractTransactor) (*EmitterTransactor, error) {
+	contract, err := bindEmitter(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterTransactor{contract: contract}, nil
+}
+
+// NewEmitterFilterer creates a new log filterer instance of Emitter, bound to a specific deployed contract.
+func NewEmitterFilterer(address common.Address, filterer bind.ContractFilterer) (*EmitterFilterer, error) {
+	contract, err := bindEmitter(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterFilterer{contract: contract}, nil
+}
+
+// bindEmitter binds a generic wrapper to an already deployed contract.
+func bindEmitter(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := EmitterMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Emitter *EmitterRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Emitter.Contract.EmitterCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Emitter *EmitterRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitterTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Emitter *EmitterRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitterTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Emitter *EmitterCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Emitter.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Emitter *EmitterTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Emitter.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Emitter *EmitterTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Emitter.Contract.contract.Transact(opts, method, params...)
+}
+
+// EmitFive is a paid mutator transaction binding the contract method 0x6995a2d9.
+//
+// Solidity: function emitFive(uint256 one, uint256 two, uint256 three, bytes four, bytes five) returns()
+func (_Emitter *EmitterTransactor) EmitFive(opts *bind.TransactOpts, one *big.Int, two *big.Int, three *big.Int, four []byte, five []byte) (*types.Transaction, error) {
+	return _Emitter.contract.Transact(opts, "emitFive", one, two, three, four, five)
+}
+
+// EmitFive is a paid mutator transaction binding the contract method 0x6995a2d9.
+//
+// Solidity: function emitFive(uint256 one, uint256 two, uint256 three, bytes four, bytes five) returns()
+func (_Emitter *EmitterSession) EmitFive(one *big.Int, two *big.Int, three *big.Int, four []byte, five []byte) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitFive(&_Emitter.TransactOpts, one, two, three, four, five)
+}
+
+// EmitFive is a paid mutator transaction binding the contract method 0x6995a2d9.
+//
+// Solidity: function emitFive(uint256 one, uint256 two, uint256 three, bytes four, bytes five) returns()
+func (_Emitter *EmitterTransactorSession) EmitFive(one *big.Int, two *big.Int, three *big.Int, four []byte, five []byte) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitFive(&_Emitter.TransactOpts, one, two, three, four, five)
+}
+
+// EmitFour is a paid mutator transaction binding the contract method 0x8cc5e892.
+//
+// Solidity: function emitFour(uint256 one, uint256 two, uint256 three, bytes four) returns()
+func (_Emitter *EmitterTransactor) EmitFour(opts *bind.TransactOpts, one *big.Int, two *big.Int, three *big.Int, four []byte) (*types.Transaction, error) {
+	return _Emitter.contract.Transact(opts, "emitFour", one, two, three, four)
+}
+
+// EmitFour is a paid mutator transaction binding the contract method 0x8cc5e892.
+//
+// Solidity: function emitFour(uint256 one, uint256 two, uint256 three, bytes four) returns()
+func (_Emitter *EmitterSession) EmitFour(one *big.Int, two *big.Int, three *big.Int, four []byte) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitFour(&_Emitter.TransactOpts, one, two, three, four)
+}
+
+// EmitFour is a paid mutator transaction binding the contract method 0x8cc5e892.
+//
+// Solidity: function emitFour(uint256 one, uint256 two, uint256 three, bytes four) returns()
+func (_Emitter *EmitterTransactorSession) EmitFour(one *big.Int, two *big.Int, three *big.Int, four []byte) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitFour(&_Emitter.TransactOpts, one, two, three, four)
+}
+
+// EmitSix is a paid mutator transaction binding the contract method 0xf70770e0.
+//
+// Solidity: function emitSix(uint256 one, string two, address three, bytes four, uint256 five, bytes six) returns()
+func (_Emitter *EmitterTransactor) EmitSix(opts *bind.TransactOpts, one *big.Int, two string, three common.Address, four []byte, five *big.Int, six []byte) (*types.Transaction, error) {
+	return _Emitter.contract.Transact(opts, "emitSix", one, two, three, four, five, six)
+}
+
+// EmitSix is a paid mutator transaction binding the contract method 0xf70770e0.
+//
+// Solidity: function emitSix(uint256 one, string two, address three, bytes four, uint256 five, bytes six) returns()
+func (_Emitter *EmitterSession) EmitSix(one *big.Int, two string, three common.Address, four []byte, five *big.Int, six []byte) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitSix(&_Emitter.TransactOpts, one, two, three, four, five, six)
+}
+
+// EmitSix is a paid mutator transaction binding the contract method 0xf70770e0.
+//
+// Solidity: function emitSix(uint256 one, string two, address three, bytes four, uint256 five, bytes six) returns()
+func (_Emitter *EmitterTransactorSession) EmitSix(one *big.Int, two string, three common.Address, four []byte, five *big.Int, six []byte) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitSix(&_Emitter.TransactOpts, one, two, three, four, five, six)
+}
+
+// EmitTwo is a paid mutator transaction binding the contract method 0x7155880d.
+//
+// Solidity: function emitTwo(uint256 value) returns()
+func (_Emitter *EmitterTransactor) EmitTwo(opts *bind.TransactOpts, value *big.Int) (*types.Transaction, error) {
+	return _Emitter.contract.Transact(opts, "emitTwo", value)
+}
+
+// EmitTwo is a paid mutator transaction binding the contract method 0x7155880d.
+//
+// Solidity: function emitTwo(uint256 value) returns()
+func (_Emitter *EmitterSession) EmitTwo(value *big.Int) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitTwo(&_Emitter.TransactOpts, value)
+}
+
+// EmitTwo is a paid mutator transaction binding the contract method 0x7155880d.
+//
+// Solidity: function emitTwo(uint256 value) returns()
+func (_Emitter *EmitterTransactorSession) EmitTwo(value *big.Int) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitTwo(&_Emitter.TransactOpts, value)
+}
+
+// EmitterFiveIterator is returned from FilterFive and is used to iterate over the raw logs and unpacked data for Five events raised by the Emitter contract.
+type EmitterFiveIterator struct {
+	Event *EmitterFive // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EmitterFiveIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EmitterFive)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EmitterFive)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EmitterFiveIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EmitterFiveIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EmitterFive represents a Five event raised by the Emitter contract.
+type EmitterFive struct {
+	One   *big.Int
+	Two   *big.Int
+	Three *big.Int
+	Four  []byte
+	Five  []byte
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterFive is a free log retrieval operation binding the contract event 0x2778059b9d45e2cd0df03a27bbe3e688dfc48aa15a729c42f39dcd986ebd4461.
+//
+// Solidity: event Five(uint256 indexed one, uint256 indexed two, uint256 indexed three, bytes four, bytes five)
+func (_Emitter *EmitterFilterer) FilterFive(opts *bind.FilterOpts, one []*big.Int, two []*big.Int, three []*big.Int) (*EmitterFiveIterator, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+	var twoRule []interface{}
+	for _, twoItem := range two {
+		twoRule = append(twoRule, twoItem)
+	}
+	var threeRule []interface{}
+	for _, threeItem := range three {
+		threeRule = append(threeRule, threeItem)
+	}
+
+	logs, sub, err := _Emitter.contract.FilterLogs(opts, "Five", oneRule, twoRule, threeRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterFiveIterator{contract: _Emitter.contract, event: "Five", logs: logs, sub: sub}, nil
+}
+
+// WatchFive is a free log subscription operation binding the contract event 0x2778059b9d45e2cd0df03a27bbe3e688dfc48aa15a729c42f39dcd986ebd4461.
+//
+// Solidity: event Five(uint256 indexed one, uint256 indexed two, uint256 indexed three, bytes four, bytes five)
+func (_Emitter *EmitterFilterer) WatchFive(opts *bind.WatchOpts, sink chan<- *EmitterFive, one []*big.Int, two []*big.Int, three []*big.Int) (event.Subscription, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+	var twoRule []interface{}
+	for _, twoItem := range two {
+		twoRule = append(twoRule, twoItem)
+	}
+	var threeRule []interface{}
+	for _, threeItem := range three {
+		threeRule = append(threeRule, threeItem)
+	}
+
+	logs, sub, err := _Emitter.contract.WatchLogs(opts, "Five", oneRule, twoRule, threeRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EmitterFive)
+				if err := _Emitter.contract.UnpackLog(event, "Five", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFive is a log parse operation binding the contract event 0x2778059b9d45e2cd0df03a27bbe3e688dfc48aa15a729c42f39dcd986ebd4461.
+//
+// Solidity: event Five(uint256 indexed one, uint256 indexed two, uint256 indexed three, bytes four, bytes five)
+func (_Emitter *EmitterFilterer) ParseFive(log types.Log) (*EmitterFive, error) {
+	event := new(EmitterFive)
+	if err := _Emitter.contract.UnpackLog(event, "Five", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EmitterFourIterator is returned from FilterFour and is used to iterate over the raw logs and unpacked data for Four events raised by the Emitter contract.
+type EmitterFourIterator struct {
+	Event *EmitterFour // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EmitterFourIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EmitterFour)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EmitterFour)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EmitterFourIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EmitterFourIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EmitterFour represents a Four event raised by the Emitter contract.
+type EmitterFour struct {
+	One   *big.Int
+	Two   *big.Int
+	Three *big.Int
+	Four  []byte
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterFour is a free log retrieval operation binding the contract event 0xd82c9bd67140e94b50e0a62e800c51428267b0cd733573daaafad26b62c05afb.
+//
+// Solidity: event Four(uint256 indexed one, uint256 indexed two, uint256 indexed three, bytes four)
+func (_Emitter *EmitterFilterer) FilterFour(opts *bind.FilterOpts, one []*big.Int, two []*big.Int, three []*big.Int) (*EmitterFourIterator, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+	var twoRule []interface{}
+	for _, twoItem := range two {
+		twoRule = append(twoRule, twoItem)
+	}
+	var threeRule []interface{}
+	for _, threeItem := range three {
+		threeRule = append(threeRule, threeItem)
+	}
+
+	logs, sub, err := _Emitter.contract.FilterLogs(opts, "Four", oneRule, twoRule, threeRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterFourIterator{contract: _Emitter.contract, event: "Four", logs: logs, sub: sub}, nil
+}
+
+// WatchFour is a free log subscription operation binding the contract event 0xd82c9bd67140e94b50e0a62e800c51428267b0cd733573daaafad26b62c05afb.
+//
+// Solidity: event Four(uint256 indexed one, uint256 indexed two, uint256 indexed three, bytes four)
+func (_Emitter *EmitterFilterer) WatchFour(opts *bind.WatchOpts, sink chan<- *EmitterFour, one []*big.Int, two []*big.Int, three []*big.Int) (event.Subscription, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+	var twoRule []interface{}
+	for _, twoItem := range two {
+		twoRule = append(twoRule, twoItem)
+	}
+	var threeRule []interface{}
+	for _, threeItem := range three {
+		threeRule = append(threeRule, threeItem)
+	}
+
+	logs, sub, err := _Emitter.contract.WatchLogs(opts, "Four", oneRule, twoRule, threeRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EmitterFour)
+				if err := _Emitter.contract.UnpackLog(event, "Four", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFour is a log parse operation binding the contract event 0xd82c9bd67140e94b50e0a62e800c51428267b0cd733573daaafad26b62c05afb.
+//
+// Solidity: event Four(uint256 indexed one, uint256 indexed two, uint256 indexed three, bytes four)
+func (_Emitter *EmitterFilterer) ParseFour(log types.Log) (*EmitterFour, error) {
+	event := new(EmitterFour)
+	if err := _Emitter.contract.UnpackLog(event, "Four", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EmitterSixIterator is returned from FilterSix and is used to iterate over the raw logs and unpacked data for Six events raised by the Emitter contract.
+type EmitterSixIterator struct {
+	Event *EmitterSix // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EmitterSixIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EmitterSix)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EmitterSix)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EmitterSixIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EmitterSixIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EmitterSix represents a Six event raised by the Emitter contract.
+type EmitterSix struct {
+	One   *big.Int
+	Two   common.Hash
+	Three common.Address
+	Four  []byte
+	Five  *big.Int
+	Six   []byte
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterSix is a free log retrieval operation binding the contract event 0x1c49d7caedaa8e8be0f2ef7b3c285ccaef7eac5a7fe6b427cbe7e7d8ad307054.
+//
+// Solidity: event Six(uint256 indexed one, string indexed two, address indexed three, bytes four, uint256 five, bytes six)
+func (_Emitter *EmitterFilterer) FilterSix(opts *bind.FilterOpts, one []*big.Int, two []string, three []common.Address) (*EmitterSixIterator, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+	var twoRule []interface{}
+	for _, twoItem := range two {
+		twoRule = append(twoRule, twoItem)
+	}
+	var threeRule []interface{}
+	for _, threeItem := range three {
+		threeRule = append(threeRule, threeItem)
+	}
+
+	logs, sub, err := _Emitter.contract.FilterLogs(opts, "Six", oneRule, twoRule, threeRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterSixIterator{contract: _Emitter.contract, event: "Six", logs: logs, sub: sub}, nil
+}
+
+// WatchSix is a free log subscription operation binding the contract event 0x1c49d7caedaa8e8be0f2ef7b3c285ccaef7eac5a7fe6b427cbe7e7d8ad307054.
+//
+// Solidity: event Six(uint256 indexed one, string indexed two, address indexed three, bytes four, uint256 five, bytes six)
+func (_Emitter *EmitterFilterer) WatchSix(opts *bind.WatchOpts, sink chan<- *EmitterSix, one []*big.Int, two []string, three []common.Address) (event.Subscription, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+	var twoRule []interface{}
+	for _, twoItem := range two {
+		twoRule = append(twoRule, twoItem)
+	}
+	var threeRule []interface{}
+	for _, threeItem := range three {
+		threeRule = append(threeRule, threeItem)
+	}
+
+	logs, sub, err := _Emitter.contract.WatchLogs(opts, "Six", oneRule, twoRule, threeRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EmitterSix)
+				if err := _Emitter.contract.UnpackLog(event, "Six", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSix is a log parse operation binding the contract event 0x1c49d7caedaa8e8be0f2ef7b3c285ccaef7eac5a7fe6b427cbe7e7d8ad307054.
+//
+// Solidity: event Six(uint256 indexed one, string indexed two, address indexed three, bytes four, uint256 five, bytes six)
+func (_Emitter *EmitterFilterer) ParseSix(log types.Log) (*EmitterSix, error) {
+	event := new(EmitterSix)
+	if err := _Emitter.contract.UnpackLog(event, "Six", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EmitterTwoIterator is returned from FilterTwo and is used to iterate over the raw logs and unpacked data for Two events raised by the Emitter contract.
+type EmitterTwoIterator struct {
+	Event *EmitterTwo // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EmitterTwoIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EmitterTwo)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EmitterTwo)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EmitterTwoIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EmitterTwoIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EmitterTwo represents a Two event raised by the Emitter contract.
+type EmitterTwo struct {
+	NewValue *big.Int
+	Value    *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterTwo is a free log retrieval operation binding the contract event 0xce34f015a0e20f2b0daf980b28ed50729e87b993e4d30cca4c3f4da05acbd0ac.
+//
+// Solidity: event Two(uint256 indexed newValue, uint256 value)
+func (_Emitter *EmitterFilterer) FilterTwo(opts *bind.FilterOpts, newValue []*big.Int) (*EmitterTwoIterator, error) {
+	var newValueRule []interface{}
+	for _, newValueItem := range newValue {
+		newValueRule = append(newValueRule, newValueItem)
+	}
+
+	logs, sub, err := _Emitter.contract.FilterLogs(opts, "Two", newValueRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterTwoIterator{contract: _Emitter.contract, event: "Two", logs: logs, sub: sub}, nil
+}
+
+// WatchTwo is a free log subscription operation binding the contract event 0xce34f015a0e20f2b0daf980b28ed50729e87b993e4d30cca4c3f4da05acbd0ac.
+//
+// Solidity: event Two(uint256 indexed newValue, uint256 value)
+func (_Emitter *EmitterFilterer) WatchTwo(opts *bind.WatchOpts, sink chan<- *EmitterTwo, newValue []*big.Int) (event.Subscription, error) {
+	var newValueRule []interface{}
+	for _, newValueItem := range newValue {
+		newValueRule = append(newValueRule, newValueItem)
+	}
+
+	logs, sub, err := _Emitter.contract.WatchLogs(opts, "Two", newValueRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EmitterTwo)
+				if err := _Emitter.contract.UnpackLog(event, "Two", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTwo is a log parse operation binding the contract event 0xce34f015a0e20f2b0daf980b28ed50729e87b993e4d30cca4c3f4da05acbd0ac.
+//
+// Solidity: event Two(uint256 indexed newValue, uint256 value)
+func (_Emitter *EmitterFilterer) ParseTwo(log types.Log) (*EmitterTwo, error) {
+	event := new(EmitterTwo)
+	if err := _Emitter.contract.UnpackLog(event, "Two", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	Word    = 32
-	Version = 0x1
+	Version = 0x2
 )
 
 // EventTriggerDefinition specifies an event-based trigger.

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -309,7 +309,7 @@ func (r *LogValueRef) GetOffsetDataValue(log *types.Log) []byte {
 	return value
 }
 
-// aligns []byte to 32 byte
+// aligns []byte to 32 byte.
 func Align(val []byte) []byte {
 	words := (31 + len(val)) / Word
 	x := make([]byte, Word*words)

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -448,11 +448,6 @@ func (p *ValuePredicate) validateArgValues() error {
 			return fmt.Errorf("integer argument %d cannot be negative for operation %d", i, p.Op)
 		}
 	}
-	// for i, arg := range p.ByteArgs {
-	// 	if len(arg) > Word {
-	// 		return fmt.Errorf("size of byte argument %d larger than 32 bytes for operation %d, got %d bytes", i, p.Op, len(arg))
-	// 	}
-	// }
 	return nil
 }
 

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -39,7 +39,6 @@ type LogPredicate struct {
 //     byte 32, ends at byte 96 (exclusive), and is 64 bytes long.
 type LogValueRef struct {
 	Offset uint64
-	Length uint64
 }
 
 // ValuePredicate defines a condition on a value contained in an event log that must be satisfied
@@ -159,8 +158,10 @@ func (d *EventTriggerDefinition) ToFilterQuery() (ethereum.FilterQuery, error) {
 // Match checks if the log matches the event trigger definition by checking all log predicates.
 //
 // This may panic if Validate does not pass.
+// We need to match ABI encoding: https://docs.soliditylang.org/en/latest/abi-spec.html
 func (d *EventTriggerDefinition) Match(log *types.Log) (bool, error) {
 	if log.Address != d.Contract {
+		fmt.Println("Contract mismatch")
 		return false, nil
 	}
 	for _, logPredicate := range d.LogPredicates {
@@ -179,50 +180,39 @@ func (p *LogPredicate) Validate() error {
 	if err := p.LogValueRef.Validate(); err != nil {
 		return err
 	}
-	if err := p.ValuePredicate.Validate(p.LogValueRef.Length); err != nil {
+	if err := p.ValuePredicate.Validate(); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (p *LogPredicate) Match(log *types.Log) (bool, error) {
-	value := p.LogValueRef.GetValue(log)
+	var value []byte
+	if p.ValuePredicate.Op != BytesEq || p.LogValueRef.IsTopic() {
+		value = p.LogValueRef.GetValue(log)
+	} else {
+		value = p.LogValueRef.GetOffsetDataValue(log)
+	}
 	return p.ValuePredicate.Match(value)
 }
 
 func (r *LogValueRef) Validate() error {
-	if r.Length == 0 {
-		return fmt.Errorf("log value reference length must be positive, got %d", r.Length)
-	}
-	if r.Offset < 4 && r.Length != 1 {
-		return fmt.Errorf("log value reference offset < 4 requires length to be 1, got %d", r.Length)
-	}
-	// Check that the offset and length are within reasonable bounds so that we can convert them
+	// Check that the offset is within reasonable bounds so that we can convert them
 	// to bytes and bits without worrying.
 	if r.Offset > math.MaxUint32 {
 		return fmt.Errorf("log value reference offset must be less than 2^32, got %d", r.Offset)
-	}
-	if r.Length > math.MaxUint32 {
-		return fmt.Errorf("log value reference length must be less than 2^32, got %d", r.Length)
 	}
 	return nil
 }
 
 func (r *LogValueRef) EncodeRLP(w io.Writer) error {
 	buf := rlp.NewEncoderBuffer(w)
-	if r.Length == 1 {
-		buf.WriteUint64(r.Offset)
-	} else {
-		listIndex := buf.List()
-		buf.WriteUint64(r.Offset)
-		buf.WriteUint64(r.Length)
-		buf.ListEnd(listIndex)
-	}
+	buf.WriteUint64(r.Offset)
 	return buf.Flush()
 }
 
 func (r *LogValueRef) DecodeRLP(s *rlp.Stream) error {
-	var offset, length uint64
+	var offset uint64
 	kind, _, err := s.Kind()
 	if err != nil {
 		return fmt.Errorf("failed to decode LogValueRef: %w", err)
@@ -233,29 +223,12 @@ func (r *LogValueRef) DecodeRLP(s *rlp.Stream) error {
 		if err != nil {
 			return fmt.Errorf("failed to read offset from LogValueRef: %w", err)
 		}
-		length = 1
 	case rlp.List:
-		_, err = s.List()
-		if err != nil {
-			return fmt.Errorf("failed to read LogValueRef list: %w", err)
-		}
-		offset, err = s.Uint64()
-		if err != nil {
-			return fmt.Errorf("failed to read offset from LogValueRef: %w", err)
-		}
-		length, err = s.Uint64()
-		if err != nil {
-			return fmt.Errorf("failed to read length from LogValueRef: %w", err)
-		}
-		err = s.ListEnd()
-		if err != nil {
-			return fmt.Errorf("failed to decode LogValueRef: %w", err)
-		}
+		return fmt.Errorf("LogValueRef can't be a list")
 	default:
 		panic(fmt.Sprintf("unexpected kind %d for LogValueRef", kind))
 	}
 	r.Offset = offset
-	r.Length = length
 	if err := r.Validate(); err != nil {
 		return fmt.Errorf("invalid LogValueRef: %w", err)
 	}
@@ -266,7 +239,7 @@ func (r *LogValueRef) IsTopic() bool {
 	return r.Offset < 4
 }
 
-// GetValue retrieves the value from the log based on the LogValueRef.
+// GetValue retrieves a one-word value from the log based on the LogValueRef.
 //
 // In case a slice of log data is referenced and the slice exceeds the log's data length, the
 // result will be zero-padded on the right to the expected length.
@@ -279,10 +252,10 @@ func (r *LogValueRef) GetValue(log *types.Log) []byte {
 	}
 
 	dataOffset := r.Offset - 4
-	value := make([]byte, r.Length*Word)
+	value := make([]byte, Word)
 
 	startByte := dataOffset * Word
-	endByte := (dataOffset + r.Length) * Word
+	endByte := (dataOffset + 1) * Word
 
 	if startByte < uint64(len(log.Data)) {
 		availableEnd := uint64(len(log.Data))
@@ -293,6 +266,55 @@ func (r *LogValueRef) GetValue(log *types.Log) []byte {
 	}
 
 	return value
+}
+
+// GetOffsetDataValue retrieves a "complex" data value from the log based on the LogValueRef.
+//
+// In case a slice of log data is referenced and the slice exceeds the log's data length, the
+// result will be zero-padded on the right to the expected length.
+func (r *LogValueRef) GetOffsetDataValue(log *types.Log) []byte {
+	// abi encoded log data:
+	// W1: first argument value (simple) or offset_0 (complex)
+	// W2: second argument value (simple) or offset_1 (complex)
+	// W..@offset_0: size_0 for first complex argument
+	// W..@offset_0+W: start of data for first complex argument
+	//
+	// we need to discriminate between literal/simple and complex arguments
+	// - simple are found in `data[(offset-4)*WORD:(offset-4+1)*WORD]`
+	// - complex are found by
+	// 		- reading the `internal_offset` from `data[(offset-4)*WORD:(offset-4+1)*WORD]`
+	//		- reading the `value_length` from `data[internal_offset:internal_offset+WORD]`
+	//		- reading the `value` from `data[internal_offset+WORD:internal_offset+WORD+value_length]`
+	//
+	dataOffset := r.Offset - 4
+
+	offsetStartByte := dataOffset * Word
+
+	x := log.Data[offsetStartByte : offsetStartByte+Word]
+
+	lengthByteOffset := new(big.Int).SetBytes(x).Uint64()
+	y := log.Data[lengthByteOffset : lengthByteOffset+Word]
+	length := new(big.Int).SetBytes(y).Uint64()
+	value := make([]byte, length)
+	startByte := lengthByteOffset + Word
+	endByte := startByte + length
+
+	if startByte < uint64(len(log.Data)) {
+		availableEnd := uint64(len(log.Data))
+		if endByte < availableEnd {
+			availableEnd = endByte
+		}
+		copy(value, log.Data[startByte:availableEnd])
+	}
+	return value
+}
+
+// aligns []byte to 32 byte
+func Align(val []byte) []byte {
+	words := (31 + len(val)) / Word
+	x := make([]byte, Word*words)
+	copy(x[len(x)-len(val):], val)
+	return x
 }
 
 const (
@@ -391,14 +413,14 @@ func (p *ValuePredicate) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
-func (p *ValuePredicate) Validate(numWords uint64) error {
+func (p *ValuePredicate) Validate() error {
 	if err := p.Op.Validate(); err != nil {
 		return err
 	}
 	if err := p.validateArgNums(); err != nil {
 		return err
 	}
-	if err := p.validateArgValues(numWords); err != nil {
+	if err := p.validateArgValues(); err != nil {
 		return err
 	}
 	return nil
@@ -417,7 +439,7 @@ func (p *ValuePredicate) validateArgNums() error {
 	return nil
 }
 
-func (p *ValuePredicate) validateArgValues(numWords uint64) error {
+func (p *ValuePredicate) validateArgValues() error {
 	for i, arg := range p.IntArgs {
 		if arg == nil {
 			return fmt.Errorf("integer argument %d cannot be nil for operation %d", i, p.Op)
@@ -425,21 +447,12 @@ func (p *ValuePredicate) validateArgValues(numWords uint64) error {
 		if arg.Sign() < 0 {
 			return fmt.Errorf("integer argument %d cannot be negative for operation %d", i, p.Op)
 		}
-		if uint64(arg.BitLen()) > numWords*Word*8 {
-			return fmt.Errorf(
-				"bit length of integer argument %d cannot exceed value bit length %d for operation %d, got %d bits",
-				i, numWords*Word*8, p.Op, arg.BitLen(),
-			)
-		}
 	}
-	for i, arg := range p.ByteArgs {
-		if uint64(len(arg)) != numWords*Word {
-			return fmt.Errorf(
-				"size of byte argument %d must match size of value (%d bytes) for operation %d, got %d bytes",
-				i, numWords*Word, p.Op, len(arg),
-			)
-		}
-	}
+	// for i, arg := range p.ByteArgs {
+	// 	if len(arg) > Word {
+	// 		return fmt.Errorf("size of byte argument %d larger than 32 bytes for operation %d, got %d bytes", i, p.Op, len(arg))
+	// 	}
+	// }
 	return nil
 }
 

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -281,6 +281,7 @@ func (r *LogValueRef) GetOffsetDataValue(log *types.Log) []byte {
 	// W..@offset_0+W: start of data for first complex argument
 	//
 	// we need to discriminate between literal/simple and complex arguments
+	// - topic data (i.e. offset < 4) is always read as a whole word by `GetValue`
 	// - simple are found in `data[(offset-4)*WORD:(offset-4+1)*WORD]`
 	// - complex are found by
 	// 		- reading the `internal_offset` from `data[(offset-4)*WORD:(offset-4+1)*WORD]`

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -163,7 +163,6 @@ func (d *EventTriggerDefinition) ToFilterQuery() (ethereum.FilterQuery, error) {
 // We need to match ABI encoding: https://docs.soliditylang.org/en/latest/abi-spec.html
 func (d *EventTriggerDefinition) Match(log *types.Log) (bool, error) {
 	if log.Address != d.Contract {
-		fmt.Println("Contract mismatch")
 		return false, nil
 	}
 	for _, logPredicate := range d.LogPredicates {

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -32,11 +32,11 @@ type LogPredicate struct {
 }
 
 // LogValueRef references a value contained in an event log.
-//   - If 0 <= Offset < 4, it refers to the topic of the log at index Offset. In this case, Length
-//     must be 1.
-//   - If Offset >= 4, it refers to a slice of 32-byte words from the log's data. Its start index is
-//     Offset - 4 and the length is Length. E.g., for offset 5 and length 2, the slice starts at
-//     byte 32, ends at byte 96 (exclusive), and is 64 bytes long.
+//   - If 0 <= Offset < 4, it refers to the topic of the log at index Offset. In this case, there is always
+//     one whole 32 byte word.
+//   - If Offset >= 4, it refers to a slice from the log's data. Its start index is at
+//     (Offset - 4) * 32 and the length is encoded according to the ABI event encoding spec
+//     (https://docs.soliditylang.org/en/latest/abi-spec.html).
 type LogValueRef struct {
 	Offset uint64
 }
@@ -138,11 +138,13 @@ func (d *EventTriggerDefinition) ToFilterQuery() (ethereum.FilterQuery, error) {
 			topics = append(topics, []common.Hash{})
 		}
 		if len(topics[topicIndex]) != 0 {
-			return ethereum.FilterQuery{}, fmt.Errorf("multiple log predicates for topic %d", topicIndex)
+			return ethereum.FilterQuery{}, fmt.Errorf(
+				"multiple log predicates for topic %d", topicIndex)
 		}
 		topic := logPredicate.ValuePredicate.ByteArgs[0]
 		if len(topic) != Word {
-			return ethereum.FilterQuery{}, fmt.Errorf("log predicate for topic %d must have a 32-byte value, got %d bytes", topicIndex, len(topic))
+			return ethereum.FilterQuery{}, fmt.Errorf(
+				"log predicate for topic %d must have a 32-byte value, got %d bytes", topicIndex, len(topic))
 		}
 		topics[logPredicate.LogValueRef.Offset] = []common.Hash{common.BytesToHash(topic)}
 	}
@@ -434,7 +436,8 @@ func (p *ValuePredicate) validateArgNums() error {
 		return fmt.Errorf("operation %d requires exactly %d integer argument(s), got %d", p.Op, requiredIntArgs, len(p.IntArgs))
 	}
 	if len(p.ByteArgs) != requiredByteArgs {
-		return fmt.Errorf("operation %d requires exactly %d bytes argument(s), got %d", p.Op, requiredByteArgs, len(p.ByteArgs))
+		return fmt.Errorf("operation %d requires exactly %d bytes argument(s), got %d",
+			p.Op, requiredByteArgs, len(p.ByteArgs))
 	}
 	return nil
 }

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -311,14 +311,6 @@ func (r *LogValueRef) GetOffsetDataValue(log *types.Log) []byte {
 	return value
 }
 
-// aligns []byte to 32 byte.
-func Align(val []byte) []byte {
-	words := (31 + len(val)) / Word
-	x := make([]byte, Word*words)
-	copy(x[len(x)-len(val):], val)
-	return x
-}
-
 const (
 	UintLt Op = iota
 	UintLte

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -205,43 +205,6 @@ func (r *LogValueRef) Validate() error {
 	return nil
 }
 
-func (r *LogValueRef) EncodeRLP(w io.Writer) error {
-	buf := rlp.NewEncoderBuffer(w)
-	buf.WriteBool(r.Dynamic)
-	buf.WriteUint64(r.Offset)
-	return buf.Flush()
-}
-
-func (r *LogValueRef) DecodeRLP(s *rlp.Stream) error {
-	var dynamic bool
-	var offset uint64
-	kind, _, err := s.Kind()
-	if err != nil {
-		return fmt.Errorf("failed to decode LogValueRef: %w", err)
-	}
-	switch kind {
-	case rlp.Byte, rlp.String:
-		dynamic, err = s.Bool()
-		if err != nil {
-			return fmt.Errorf("failed to read dynamic from LogValueRef: %w", err)
-		}
-		offset, err = s.Uint64()
-		if err != nil {
-			return fmt.Errorf("failed to read offset from LogValueRef: %w", err)
-		}
-	case rlp.List:
-		return fmt.Errorf("LogValueRef can't be a list")
-	default:
-		panic(fmt.Sprintf("unexpected kind %d for LogValueRef", kind))
-	}
-	r.Dynamic = dynamic
-	r.Offset = offset
-	if err := r.Validate(); err != nil {
-		return fmt.Errorf("invalid LogValueRef: %w", err)
-	}
-	return nil
-}
-
 func (r *LogValueRef) IsTopic() bool {
 	return r.Offset < 4
 }

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger.go
@@ -38,7 +38,8 @@ type LogPredicate struct {
 //     (Offset - 4) * 32 and the length is encoded according to the ABI event encoding spec
 //     (https://docs.soliditylang.org/en/latest/abi-spec.html).
 type LogValueRef struct {
-	Offset uint64
+	Dynamic bool
+	Offset  uint64
 }
 
 // ValuePredicate defines a condition on a value contained in an event log that must be satisfied
@@ -188,12 +189,7 @@ func (p *LogPredicate) Validate() error {
 }
 
 func (p *LogPredicate) Match(log *types.Log) (bool, error) {
-	var value []byte
-	if p.ValuePredicate.Op != BytesEq || p.LogValueRef.IsTopic() {
-		value = p.LogValueRef.GetValue(log)
-	} else {
-		value = p.LogValueRef.GetOffsetDataValue(log)
-	}
+	value := p.LogValueRef.GetValue(log)
 	return p.ValuePredicate.Match(value)
 }
 
@@ -203,16 +199,21 @@ func (r *LogValueRef) Validate() error {
 	if r.Offset > math.MaxUint32 {
 		return fmt.Errorf("log value reference offset must be less than 2^32, got %d", r.Offset)
 	}
+	if r.Dynamic && r.Offset < 4 {
+		return fmt.Errorf("topic values (offset < 4) are always fixed size of one word, got offset %d", r.Offset)
+	}
 	return nil
 }
 
 func (r *LogValueRef) EncodeRLP(w io.Writer) error {
 	buf := rlp.NewEncoderBuffer(w)
+	buf.WriteBool(r.Dynamic)
 	buf.WriteUint64(r.Offset)
 	return buf.Flush()
 }
 
 func (r *LogValueRef) DecodeRLP(s *rlp.Stream) error {
+	var dynamic bool
 	var offset uint64
 	kind, _, err := s.Kind()
 	if err != nil {
@@ -220,6 +221,10 @@ func (r *LogValueRef) DecodeRLP(s *rlp.Stream) error {
 	}
 	switch kind {
 	case rlp.Byte, rlp.String:
+		dynamic, err = s.Bool()
+		if err != nil {
+			return fmt.Errorf("failed to read dynamic from LogValueRef: %w", err)
+		}
 		offset, err = s.Uint64()
 		if err != nil {
 			return fmt.Errorf("failed to read offset from LogValueRef: %w", err)
@@ -229,6 +234,7 @@ func (r *LogValueRef) DecodeRLP(s *rlp.Stream) error {
 	default:
 		panic(fmt.Sprintf("unexpected kind %d for LogValueRef", kind))
 	}
+	r.Dynamic = dynamic
 	r.Offset = offset
 	if err := r.Validate(); err != nil {
 		return fmt.Errorf("invalid LogValueRef: %w", err)
@@ -240,9 +246,9 @@ func (r *LogValueRef) IsTopic() bool {
 	return r.Offset < 4
 }
 
-// GetValue retrieves a one-word value from the log based on the LogValueRef.
+// GetValue retrieves a slice from the log based on the LogValueRef.
 //
-// In case a slice of log data is referenced and the slice exceeds the log's data length, the
+// In case the referenced slice exceeds the log's data length, the
 // result will be zero-padded on the right to the expected length.
 func (r *LogValueRef) GetValue(log *types.Log) []byte {
 	if r.IsTopic() {
@@ -252,6 +258,9 @@ func (r *LogValueRef) GetValue(log *types.Log) []byte {
 		return log.Topics[r.Offset].Bytes()
 	}
 
+	if r.Dynamic {
+		return r.getOffsetDataValue(log)
+	}
 	dataOffset := r.Offset - 4
 	value := make([]byte, Word)
 
@@ -269,11 +278,11 @@ func (r *LogValueRef) GetValue(log *types.Log) []byte {
 	return value
 }
 
-// GetOffsetDataValue retrieves a "complex" data value from the log based on the LogValueRef.
+// getOffsetDataValue retrieves a "complex" data value from the log based on the LogValueRef.
 //
 // In case a slice of log data is referenced and the slice exceeds the log's data length, the
 // result will be zero-padded on the right to the expected length.
-func (r *LogValueRef) GetOffsetDataValue(log *types.Log) []byte {
+func (r *LogValueRef) getOffsetDataValue(log *types.Log) []byte {
 	// abi encoded log data:
 	// W1: first argument value (simple) or offset_0 (complex)
 	// W2: second argument value (simple) or offset_1 (complex)

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -2084,7 +2084,7 @@ func TestWithEVM(t *testing.T) {
 	}
 	four := []byte("first and slightly longer arg that should use more space and if i am right, then this will span multiple words")
 	preFour := []byte("first and slightly longer arg that should use more space and if ")
-	mFoure := LogPredicate{
+	mFour := LogPredicate{
 		LogValueRef:    LogValueRef{Offset: 4},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{four}},
 	}
@@ -2113,8 +2113,8 @@ func TestWithEVM(t *testing.T) {
 		name       string
 	}{
 		{predicates: []LogPredicate{mOne, mTwo, mThree, mSix}, match: true, name: "match one, two, three and six"},
-		{predicates: []LogPredicate{mFoure}, match: true, name: "match four"},
-		{predicates: []LogPredicate{mFoure, mSix}, match: true, name: "match four and six"},
+		{predicates: []LogPredicate{mFour}, match: true, name: "match four"},
+		{predicates: []LogPredicate{mFour, mSix}, match: true, name: "match four and six"},
 		{
 			predicates: []LogPredicate{mSix, mSix},
 			match:      true,
@@ -2122,7 +2122,7 @@ func TestWithEVM(t *testing.T) {
 			name: "match duplicate six",
 		},
 		{predicates: []LogPredicate{preNotFour}, match: false, name: "prefix should not match whole"},
-		{predicates: []LogPredicate{noMFour, mFoure}, match: false, name: "mismatch same offset"},
+		{predicates: []LogPredicate{noMFour, mFour}, match: false, name: "mismatch same offset"},
 		{
 			predicates: []LogPredicate{
 				{

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -2,14 +2,22 @@ package shutterservice
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"log"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/ethereum/go-ethereum/rlp"
 	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
 )
 
 func TestOpValidate(t *testing.T) {
@@ -83,7 +91,6 @@ func TestLogValueRefValidate(t *testing.T) {
 			name: "valid topic reference - offset 0",
 			ref: LogValueRef{
 				Offset: 0,
-				Length: 1,
 			},
 			wantErr: false,
 		},
@@ -91,69 +98,29 @@ func TestLogValueRefValidate(t *testing.T) {
 			name: "valid topic reference - offset 3",
 			ref: LogValueRef{
 				Offset: 3,
-				Length: 1,
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid data reference - offset 4, length 1",
+			name: "valid data reference - offset 4",
 			ref: LogValueRef{
 				Offset: 4,
-				Length: 1,
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid data reference - offset 5, length 2",
+			name: "valid data reference - offset 5",
 			ref: LogValueRef{
 				Offset: 5,
-				Length: 2,
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid data reference - large offset and length",
+			name: "valid data reference - large offset",
 			ref: LogValueRef{
 				Offset: 100,
-				Length: 10,
 			},
 			wantErr: false,
-		},
-		{
-			name: "invalid zero length",
-			ref: LogValueRef{
-				Offset: 0,
-				Length: 0,
-			},
-			wantErr: true,
-			errMsg:  "log value reference length must be positive, got 0",
-		},
-		{
-			name: "invalid topic reference with length > 1 - offset 0",
-			ref: LogValueRef{
-				Offset: 0,
-				Length: 2,
-			},
-			wantErr: true,
-			errMsg:  "log value reference offset < 4 requires length to be 1, got 2",
-		},
-		{
-			name: "invalid topic reference with length > 1 - offset 1",
-			ref: LogValueRef{
-				Offset: 1,
-				Length: 3,
-			},
-			wantErr: true,
-			errMsg:  "log value reference offset < 4 requires length to be 1, got 3",
-		},
-		{
-			name: "invalid topic reference with length > 1 - offset 3",
-			ref: LogValueRef{
-				Offset: 3,
-				Length: 5,
-			},
-			wantErr: true,
-			errMsg:  "log value reference offset < 4 requires length to be 1, got 5",
 		},
 	}
 
@@ -184,8 +151,7 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{big.NewInt(100)},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  false,
+			wantErr: false,
 		},
 		{
 			name: "valid UintEq predicate",
@@ -194,8 +160,7 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{big.NewInt(42)},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  false,
+			wantErr: false,
 		},
 		{
 			name: "valid BytesEq predicate",
@@ -204,8 +169,7 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{},
 				ByteArgs: [][]byte{make([]byte, 32)}, // 32 bytes for 1 word
 			},
-			numWords: 1,
-			wantErr:  false,
+			wantErr: false,
 		},
 		{
 			name: "valid BytesEq predicate with 2 words",
@@ -214,8 +178,7 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{},
 				ByteArgs: [][]byte{make([]byte, 64)}, // 64 bytes for 2 words
 			},
-			numWords: 2,
-			wantErr:  false,
+			wantErr: false,
 		},
 		{
 			name: "invalid operation",
@@ -224,9 +187,8 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "invalid operation: 999",
+			wantErr: true,
+			errMsg:  "invalid operation: 999",
 		},
 		{
 			name: "UintLt with wrong number of int args - too few",
@@ -235,9 +197,8 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "operation 0 requires exactly 1 integer argument(s), got 0",
+			wantErr: true,
+			errMsg:  "operation 0 requires exactly 1 integer argument(s), got 0",
 		},
 		{
 			name: "UintLt with wrong number of int args - too many",
@@ -246,9 +207,8 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{big.NewInt(1), big.NewInt(2)},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "operation 0 requires exactly 1 integer argument(s), got 2",
+			wantErr: true,
+			errMsg:  "operation 0 requires exactly 1 integer argument(s), got 2",
 		},
 		{
 			name: "BytesEq with wrong number of byte args - too few",
@@ -257,9 +217,8 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "operation 5 requires exactly 1 bytes argument(s), got 0",
+			wantErr: true,
+			errMsg:  "operation 5 requires exactly 1 bytes argument(s), got 0",
 		},
 		{
 			name: "BytesEq with wrong number of byte args - too many",
@@ -268,9 +227,8 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{},
 				ByteArgs: [][]byte{make([]byte, 32), make([]byte, 32)},
 			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "operation 5 requires exactly 1 bytes argument(s), got 2",
+			wantErr: true,
+			errMsg:  "operation 5 requires exactly 1 bytes argument(s), got 2",
 		},
 		{
 			name: "UintLt with nil integer argument",
@@ -279,9 +237,8 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{nil},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "integer argument 0 cannot be nil for operation 0",
+			wantErr: true,
+			errMsg:  "integer argument 0 cannot be nil for operation 0",
 		},
 		{
 			name: "UintLt with negative integer argument",
@@ -290,25 +247,8 @@ func TestValuePredicateValidate(t *testing.T) {
 				IntArgs:  []*big.Int{big.NewInt(-1)},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "integer argument 0 cannot be negative for operation 0",
-		},
-		{
-			name: "UintLt with integer argument too large for 1 word",
-			predicate: ValuePredicate{
-				Op: UintLt,
-				IntArgs: []*big.Int{func() *big.Int {
-					// Create a number that requires more than 256 bits (1 word = 32 bytes = 256 bits)
-					val := big.NewInt(1)
-					val.Lsh(val, 257) // 2^257
-					return val
-				}()},
-				ByteArgs: [][]byte{},
-			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "bit length of integer argument 0 cannot exceed value bit length 256 for operation 0, got 258 bits",
+			wantErr: true,
+			errMsg:  "integer argument 0 cannot be negative for operation 0",
 		},
 		{
 			name: "UintLt with integer argument fitting exactly in 2 words",
@@ -322,36 +262,13 @@ func TestValuePredicateValidate(t *testing.T) {
 				}()},
 				ByteArgs: [][]byte{},
 			},
-			numWords: 2,
-			wantErr:  false,
-		},
-		{
-			name: "BytesEq with wrong byte argument size - too small",
-			predicate: ValuePredicate{
-				Op:       BytesEq,
-				IntArgs:  []*big.Int{},
-				ByteArgs: [][]byte{make([]byte, 16)}, // 16 bytes instead of 32
-			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "size of byte argument 0 must match size of value (32 bytes) for operation 5, got 16 bytes",
-		},
-		{
-			name: "BytesEq with wrong byte argument size - too large",
-			predicate: ValuePredicate{
-				Op:       BytesEq,
-				IntArgs:  []*big.Int{},
-				ByteArgs: [][]byte{make([]byte, 48)}, // 48 bytes instead of 32
-			},
-			numWords: 1,
-			wantErr:  true,
-			errMsg:   "size of byte argument 0 must match size of value (32 bytes) for operation 5, got 48 bytes",
+			wantErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.predicate.Validate(tt.numWords)
+			err := tt.predicate.Validate()
 			if tt.wantErr {
 				assert.ErrorContains(t, err, tt.errMsg)
 			} else {
@@ -963,10 +880,7 @@ func TestLogValueRefGetValue(t *testing.T) {
 		// Topic tests
 		{
 			name: "get topic 0",
-			ref: LogValueRef{
-				Offset: 0,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 0},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
@@ -978,10 +892,7 @@ func TestLogValueRefGetValue(t *testing.T) {
 		},
 		{
 			name: "get topic 1",
-			ref: LogValueRef{
-				Offset: 1,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 1},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
@@ -993,10 +904,7 @@ func TestLogValueRefGetValue(t *testing.T) {
 		},
 		{
 			name: "get topic 3 (last valid topic)",
-			ref: LogValueRef{
-				Offset: 3,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 3},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
@@ -1010,10 +918,7 @@ func TestLogValueRefGetValue(t *testing.T) {
 		},
 		{
 			name: "get topic that doesn't exist - returns nil",
-			ref: LogValueRef{
-				Offset: 2,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 2},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
@@ -1027,7 +932,6 @@ func TestLogValueRefGetValue(t *testing.T) {
 			name: "get first data word (offset 4, length 1)",
 			ref: LogValueRef{
 				Offset: 4,
-				Length: 1,
 			},
 			log: &types.Log{
 				Topics: []common.Hash{
@@ -1056,10 +960,7 @@ func TestLogValueRefGetValue(t *testing.T) {
 		},
 		{
 			name: "get second data word (offset 5, length 1)",
-			ref: LogValueRef{
-				Offset: 5,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 5},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
@@ -1085,46 +986,11 @@ func TestLogValueRefGetValue(t *testing.T) {
 				return result
 			}(),
 		},
-		{
-			name: "get two data words (offset 4, length 2)",
-			ref: LogValueRef{
-				Offset: 4,
-				Length: 2,
-			},
-			log: &types.Log{
-				Topics: []common.Hash{
-					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
-				},
-				Data: func() []byte {
-					data := make([]byte, 64)
-					// First word: 0x1111...1111
-					for i := 0; i < 32; i++ {
-						data[i] = 0x11
-					}
-					// Second word: 0x2222...2222
-					for i := 32; i < 64; i++ {
-						data[i] = 0x22
-					}
-					return data
-				}(),
-			},
-			want: func() []byte {
-				result := make([]byte, 64)
-				for i := 0; i < 32; i++ {
-					result[i] = 0x11
-				}
-				for i := 32; i < 64; i++ {
-					result[i] = 0x22
-				}
-				return result
-			}(),
-		},
+
 		{
 			name: "get data beyond log length - zero padded",
-			ref: LogValueRef{
-				Offset: 6, // Third word, but log only has 2 words
-				Length: 1,
-			},
+			// Third word, but log only has 2 words
+			ref: LogValueRef{Offset: 6},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
@@ -1140,44 +1006,8 @@ func TestLogValueRefGetValue(t *testing.T) {
 			want: make([]byte, 32), // Should return 32 zero bytes
 		},
 		{
-			name: "get partial data beyond log length - partial zero padding",
-			ref: LogValueRef{
-				Offset: 5, // Second word, but we want 2 words and log only has 2 words total
-				Length: 2,
-			},
-			log: &types.Log{
-				Topics: []common.Hash{
-					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
-				},
-				Data: func() []byte {
-					data := make([]byte, 64) // Only 2 words
-					// First word: 0x1111...1111
-					for i := 0; i < 32; i++ {
-						data[i] = 0x11
-					}
-					// Second word: 0x2222...2222
-					for i := 32; i < 64; i++ {
-						data[i] = 0x22
-					}
-					return data
-				}(),
-			},
-			want: func() []byte {
-				result := make([]byte, 64)
-				// Second word from log data
-				for i := 0; i < 32; i++ {
-					result[i] = 0x22
-				}
-				// Third word is zero-padded (bytes 32-63 remain zero)
-				return result
-			}(),
-		},
-		{
 			name: "get data from empty log data",
-			ref: LogValueRef{
-				Offset: 4,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 4},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
@@ -1216,10 +1046,7 @@ func TestEventTriggerDefinitionValidate(t *testing.T) {
 				Contract: common.HexToAddress("0x1234567890123456789012345678901234567890"),
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1236,14 +1063,11 @@ func TestEventTriggerDefinitionValidate(t *testing.T) {
 				Contract: common.HexToAddress("0x1234567890123456789012345678901234567890"),
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 0, // Invalid zero length
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
-							ByteArgs: [][]byte{make([]byte, 32)},
+							ByteArgs: [][]byte{},
 						},
 					},
 				},
@@ -1256,10 +1080,7 @@ func TestEventTriggerDefinitionValidate(t *testing.T) {
 				Contract: common.HexToAddress("0x1234567890123456789012345678901234567890"),
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1267,10 +1088,8 @@ func TestEventTriggerDefinitionValidate(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0, // Same topic as previous predicate
-							Length: 1,
-						},
+						// Same topic as previous predicate
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1287,10 +1106,7 @@ func TestEventTriggerDefinitionValidate(t *testing.T) {
 				Contract: common.HexToAddress("0x1234567890123456789012345678901234567890"),
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       UintLt, // Not BytesEq, so multiple predicates allowed
 							IntArgs:  []*big.Int{big.NewInt(100)},
@@ -1298,10 +1114,8 @@ func TestEventTriggerDefinitionValidate(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0, // Same topic, but different operation
-							Length: 1,
-						},
+						// Same topic, but different operation
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGt, // Not BytesEq, so allowed
 							IntArgs:  []*big.Int{big.NewInt(50)},
@@ -1353,10 +1167,7 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1377,10 +1188,7 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1388,10 +1196,7 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 2,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 2},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1416,10 +1221,7 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 4,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 4},
 						ValuePredicate: ValuePredicate{
 							Op:       UintLt,
 							IntArgs:  []*big.Int{big.NewInt(100)},
@@ -1440,10 +1242,7 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 1,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 1},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGt,
 							IntArgs:  []*big.Int{big.NewInt(50)},
@@ -1464,10 +1263,7 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1475,10 +1271,8 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0, // Same topic
-							Length: 1,
-						},
+						// Same topic
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1495,10 +1289,7 @@ func TestEventTriggerDefinitionToFilterQuery(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1574,10 +1365,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1601,10 +1389,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1628,10 +1413,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1639,10 +1421,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 1,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 1},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGt,
 							IntArgs:  []*big.Int{big.NewInt(50)},
@@ -1671,10 +1450,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1682,10 +1458,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 1,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 1},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGt,
 							IntArgs:  []*big.Int{big.NewInt(200)},
@@ -1716,7 +1489,6 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 					{
 						LogValueRef: LogValueRef{
 							Offset: 4,
-							Length: 1,
 						},
 						ValuePredicate: ValuePredicate{
 							Op:       UintLt,
@@ -1748,7 +1520,6 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 					{
 						LogValueRef: LogValueRef{
 							Offset: 4,
-							Length: 1,
 						},
 						ValuePredicate: ValuePredicate{
 							Op:       UintLt,
@@ -1778,10 +1549,8 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 2, // Topic index 2, but log only has 1 topic
-							Length: 1,
-						},
+						// Topic index 2, but log only has 1 topic
+						LogValueRef: LogValueRef{Offset: 2},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1805,10 +1574,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1816,10 +1582,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 4,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 4},
 						ValuePredicate: ValuePredicate{
 							Op:       UintEq,
 							IntArgs:  []*big.Int{big.NewInt(42)},
@@ -1827,10 +1590,7 @@ func TestEventTriggerDefinitionMatch(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 5,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 5},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGte,
 							IntArgs:  []*big.Int{big.NewInt(100)},
@@ -1886,10 +1646,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1905,10 +1662,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 4,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 4},
 						ValuePredicate: ValuePredicate{
 							Op:       UintLt,
 							IntArgs:  []*big.Int{big.NewInt(1000)},
@@ -1924,10 +1678,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 0,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1935,10 +1686,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 1,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 1},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGt,
 							IntArgs:  []*big.Int{big.NewInt(50)},
@@ -1946,10 +1694,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{
-							Offset: 4,
-							Length: 1,
-						},
+						LogValueRef: LogValueRef{Offset: 4},
 						ValuePredicate: ValuePredicate{
 							Op:       UintEq,
 							IntArgs:  []*big.Int{big.NewInt(42)},
@@ -1965,10 +1710,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 4,
-							Length: 2, // 2 words for large numbers
-						},
+						LogValueRef: LogValueRef{Offset: 4},
 						ValuePredicate: ValuePredicate{
 							Op: UintLte,
 							IntArgs: []*big.Int{func() *big.Int {
@@ -1988,10 +1730,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{
-							Offset: 4,
-							Length: 2, // 2 words = 64 bytes
-						},
+						LogValueRef: LogValueRef{Offset: 4},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -2007,7 +1746,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
 					{
-						LogValueRef: LogValueRef{Offset: 0, Length: 1},
+						LogValueRef: LogValueRef{Offset: 0},
 						ValuePredicate: ValuePredicate{
 							Op:       UintLt,
 							IntArgs:  []*big.Int{big.NewInt(100)},
@@ -2015,7 +1754,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{Offset: 1, Length: 1},
+						LogValueRef: LogValueRef{Offset: 1},
 						ValuePredicate: ValuePredicate{
 							Op:       UintLte,
 							IntArgs:  []*big.Int{big.NewInt(200)},
@@ -2023,7 +1762,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{Offset: 2, Length: 1},
+						LogValueRef: LogValueRef{Offset: 2},
 						ValuePredicate: ValuePredicate{
 							Op:       UintEq,
 							IntArgs:  []*big.Int{big.NewInt(42)},
@@ -2031,7 +1770,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{Offset: 3, Length: 1},
+						LogValueRef: LogValueRef{Offset: 3},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGt,
 							IntArgs:  []*big.Int{big.NewInt(300)},
@@ -2039,7 +1778,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{Offset: 4, Length: 1},
+						LogValueRef: LogValueRef{Offset: 4},
 						ValuePredicate: ValuePredicate{
 							Op:       UintGte,
 							IntArgs:  []*big.Int{big.NewInt(400)},
@@ -2047,7 +1786,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{Offset: 5, Length: 1},
+						LogValueRef: LogValueRef{Offset: 5},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -2078,7 +1817,6 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 
 				// Compare LogValueRef
 				assert.Equal(t, originalPredicate.LogValueRef.Offset, unmarshaledPredicate.LogValueRef.Offset)
-				assert.Equal(t, originalPredicate.LogValueRef.Length, unmarshaledPredicate.LogValueRef.Length)
 
 				// Compare ValuePredicate
 				assert.Equal(t, originalPredicate.ValuePredicate.Op, unmarshaledPredicate.ValuePredicate.Op)
@@ -2145,52 +1883,34 @@ func TestLogValueRefEncodeRLP(t *testing.T) {
 		expected []byte
 	}{
 		{
-			name: "topic reference - offset 0, length 1",
-			ref: LogValueRef{
-				Offset: 0,
-				Length: 1,
-			},
+			name:     "topic reference - offset 0",
+			ref:      LogValueRef{Offset: 0},
 			expected: []byte{0x80}, // RLP encoding of uint64(0)
 		},
 		{
-			name: "topic reference - offset 3, length 1",
-			ref: LogValueRef{
-				Offset: 3,
-				Length: 1,
-			},
+			name:     "topic reference - offset 3",
+			ref:      LogValueRef{Offset: 3},
 			expected: []byte{0x03}, // RLP encoding of uint64(3)
 		},
 		{
-			name: "data reference - offset 4, length 1",
-			ref: LogValueRef{
-				Offset: 4,
-				Length: 1,
-			},
+			name:     "data reference - offset 4",
+			ref:      LogValueRef{Offset: 4},
 			expected: []byte{0x04}, // RLP encoding of uint64(4)
 		},
 		{
-			name: "data reference - offset 5, length 2",
-			ref: LogValueRef{
-				Offset: 5,
-				Length: 2,
-			},
-			expected: []byte{0xc2, 0x05, 0x02}, // RLP encoding of [5, 2]
+			name:     "data reference - offset 5",
+			ref:      LogValueRef{Offset: 5},
+			expected: []byte{0x05}, // RLP encoding of uint64(5)
 		},
 		{
-			name: "data reference - offset 10, length 5",
-			ref: LogValueRef{
-				Offset: 10,
-				Length: 5,
-			},
-			expected: []byte{0xc2, 0x0a, 0x05}, // RLP encoding of [10, 5]
+			name:     "data reference - offset 10",
+			ref:      LogValueRef{Offset: 10},
+			expected: []byte{0x0a}, // RLP encoding of uint64(10)
 		},
 		{
-			name: "large offset",
-			ref: LogValueRef{
-				Offset: 1000,
-				Length: 3,
-			},
-			expected: []byte{0xc4, 0x82, 0x03, 0xe8, 0x03}, // RLP encoding of [1000, 3]
+			name:     "large offset",
+			ref:      LogValueRef{Offset: 1000},
+			expected: []byte{0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
 		},
 	}
 
@@ -2213,70 +1933,40 @@ func TestLogValueRefDecodeRLP(t *testing.T) {
 		errMsg   string
 	}{
 		{
-			name:    "topic reference - offset 0, length 1",
-			encoded: []byte{0x80}, // RLP encoding of uint64(0)
-			expected: LogValueRef{
-				Offset: 0,
-				Length: 1,
-			},
-			wantErr: false,
+			name:     "topic reference - offset 0",
+			encoded:  []byte{0x80}, // RLP encoding of uint64(0)
+			expected: LogValueRef{Offset: 0},
+			wantErr:  false,
 		},
 		{
-			name:    "topic reference - offset 3, length 1",
-			encoded: []byte{0x03}, // RLP encoding of uint64(3)
-			expected: LogValueRef{
-				Offset: 3,
-				Length: 1,
-			},
-			wantErr: false,
+			name:     "topic reference - offset 3",
+			encoded:  []byte{0x03}, // RLP encoding of uint64(3)
+			expected: LogValueRef{Offset: 3},
+			wantErr:  false,
 		},
 		{
-			name:    "data reference - offset 4, length 1",
-			encoded: []byte{0xc2, 0x04, 0x01}, // RLP encoding of [4, 1]
-			expected: LogValueRef{
-				Offset: 4,
-				Length: 1,
-			},
-			wantErr: false,
+			name:     "data reference - offset 4",
+			encoded:  []byte{0x04}, // RLP encoding of uint64(4)
+			expected: LogValueRef{Offset: 4},
+			wantErr:  false,
 		},
 		{
-			name:    "data reference - offset 5, length 2",
-			encoded: []byte{0xc2, 0x05, 0x02}, // RLP encoding of [5, 2]
-			expected: LogValueRef{
-				Offset: 5,
-				Length: 2,
-			},
-			wantErr: false,
+			name:     "data reference - offset 5",
+			encoded:  []byte{0x05}, // RLP encoding of uint64(5)
+			expected: LogValueRef{Offset: 5},
+			wantErr:  false,
 		},
 		{
-			name:    "data reference - offset 10, length 5",
-			encoded: []byte{0xc2, 0x0a, 0x05}, // RLP encoding of [10, 5]
-			expected: LogValueRef{
-				Offset: 10,
-				Length: 5,
-			},
-			wantErr: false,
+			name:     "data reference - offset 10",
+			encoded:  []byte{0x0a}, // RLP encoding of uint64(10)
+			expected: LogValueRef{Offset: 10},
+			wantErr:  false,
 		},
 		{
-			name:    "large offset",
-			encoded: []byte{0xc4, 0x82, 0x03, 0xe8, 0x03}, // RLP encoding of [1000, 3]
-			expected: LogValueRef{
-				Offset: 1000,
-				Length: 3,
-			},
-			wantErr: false,
-		},
-		{
-			name:    "invalid - zero length",
-			encoded: []byte{0xc2, 0x04, 0x80}, // RLP encoding of [4, 0]
-			wantErr: true,
-			errMsg:  "log value reference length must be positive",
-		},
-		{
-			name:    "invalid - topic with length > 1",
-			encoded: []byte{0xc2, 0x02, 0x03}, // RLP encoding of [2, 3] - topic offset with length > 1
-			wantErr: true,
-			errMsg:  "log value reference offset < 4 requires length to be 1",
+			name:     "large offset",
+			encoded:  []byte{0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
+			expected: LogValueRef{Offset: 1000},
+			wantErr:  false,
 		},
 		{
 			name:    "invalid - empty RLP data",
@@ -2294,7 +1984,7 @@ func TestLogValueRefDecodeRLP(t *testing.T) {
 			name:    "invalid - incomplete list",
 			encoded: []byte{0xc1, 0x04}, // List with only one element
 			wantErr: true,
-			errMsg:  "failed to read length from LogValueRef",
+			errMsg:  "LogValueRef can't be a list",
 		},
 	}
 
@@ -2302,6 +1992,7 @@ func TestLogValueRefDecodeRLP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var ref LogValueRef
 			err := rlp.DecodeBytes(tt.encoded, &ref)
+			fmt.Println(ref)
 
 			if tt.wantErr {
 				assert.Assert(t, err != nil, "DecodeRLP should fail")
@@ -2309,7 +2000,6 @@ func TestLogValueRefDecodeRLP(t *testing.T) {
 			} else {
 				assert.NilError(t, err, "DecodeRLP should not fail")
 				assert.Equal(t, tt.expected.Offset, ref.Offset)
-				assert.Equal(t, tt.expected.Length, ref.Length)
 			}
 		})
 	}
@@ -2322,38 +2012,23 @@ func TestLogValueRefRLPRoundTrip(t *testing.T) {
 	}{
 		{
 			name: "topic reference - offset 0",
-			ref: LogValueRef{
-				Offset: 0,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 0},
 		},
 		{
 			name: "topic reference - offset 3",
-			ref: LogValueRef{
-				Offset: 3,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 3},
 		},
 		{
 			name: "data reference - single word",
-			ref: LogValueRef{
-				Offset: 4,
-				Length: 1,
-			},
+			ref:  LogValueRef{Offset: 4},
 		},
 		{
 			name: "data reference - multiple words",
-			ref: LogValueRef{
-				Offset: 5,
-				Length: 10,
-			},
+			ref:  LogValueRef{Offset: 5},
 		},
 		{
 			name: "large values",
-			ref: LogValueRef{
-				Offset: 65535,
-				Length: 1000,
-			},
+			ref:  LogValueRef{Offset: 65535},
 		},
 	}
 
@@ -2374,13 +2049,225 @@ func TestLogValueRefRLPRoundTrip(t *testing.T) {
 
 			// Verify round trip
 			assert.Equal(t, tt.ref.Offset, decoded.Offset)
-			assert.Equal(t, tt.ref.Length, decoded.Length)
 
 			// Encode again and verify consistency
 			var buf2 bytes.Buffer
 			err = decoded.EncodeRLP(&buf2)
 			assert.NilError(t, err, "Second EncodeRLP should not fail")
 			assert.DeepEqual(t, encoded, buf2.Bytes())
+		})
+	}
+}
+
+type Setup struct {
+	backend         backends.SimulatedBackend
+	auth            *bind.TransactOpts
+	contract        *Emitter
+	contractAddress common.Address
+}
+
+func setupBackend(t *testing.T) Setup {
+	t.Helper()
+
+	// create funded genesis account
+	privateKey, err := crypto.GenerateKey()
+	assert.NilError(t, err, "failed to generate private key %v", err)
+
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1337))
+	assert.NilError(t, err, "failed to create transactor %v", err)
+
+	balance := new(big.Int)
+	balance.SetString("1000000000000000000000", 10) // 1000 ETH
+	alloc := make(types.GenesisAlloc)
+	alloc[auth.From] = types.Account{Balance: balance}
+
+	// create SimulatedBackend
+	b := simulated.NewBackend(alloc, simulated.WithBlockGasLimit(8000000))
+	backend := backends.SimulatedBackend{
+		Backend: b,
+		Client:  b.Client(),
+	}
+	// deploy Emitter contract
+	// Emitter.go is generated through `make all`
+	contractAddress, _, _, err := DeployEmitter(auth, backend)
+	assert.NilError(t, err, "failed to deploy contract: %v", err)
+	backend.Commit()
+
+	// bind contract
+	contract, err := NewEmitter(contractAddress, backend)
+	assert.NilError(t, err, "failed to bind contract instance to address %v: %v", contractAddress, err)
+
+	return Setup{
+		backend:         backend,
+		auth:            auth,
+		contract:        contract,
+		contractAddress: contractAddress,
+	}
+}
+
+func collectLog(t *testing.T, setup Setup, tx *types.Transaction) (*types.Log, error) {
+	t.Helper()
+	// Commit the block to process the transaction
+	setup.backend.Commit()
+
+	// get Receipt for Logs
+	receipt, err := setup.backend.TransactionReceipt(context.Background(), tx.Hash())
+	if err != nil {
+		log.Fatalf("Failed to get receipt: %v", err)
+	}
+	return receipt.Logs[0], nil
+}
+
+func TestWithEVM(t *testing.T) {
+	setup := setupBackend(t)
+
+	one := big.NewInt(1)
+	matchOne := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 1},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{Align(one.Bytes())}},
+	}
+
+	two := "two"
+	matchTwo := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 2},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{Align(crypto.Keccak256([]byte("two")))}},
+	}
+
+	three := common.BytesToAddress(big.NewInt(84).Bytes())
+	matchThree := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 3},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{Align(three[:])}},
+	}
+	four := []byte("first and slightly longer arg that should use more space and if i am right, then this will span multiple words")
+	notQuiteFour := []byte("first and slightly longer arg that should use more space and if ")
+	matchFour := LogPredicate{LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{four}}}
+	dontMatchFour := LogPredicate{LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{[]byte("no match")}}}
+	notQuiteMatchFour := LogPredicate{LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{notQuiteFour}}}
+
+	five := big.NewInt(42)
+
+	six := []byte("second arg")
+	matchSix := LogPredicate{LogValueRef: LogValueRef{Offset: 6}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{six}}}
+	tx, err := setup.contract.EmitSix(setup.auth, one, two, three, four, five, six)
+	assert.NilError(t, err, "error creating tx")
+	vLog, err := collectLog(t, setup, tx)
+	assert.NilError(t, err, "error getting log")
+
+	tests := []struct {
+		def    EventTriggerDefinition
+		match  bool
+		errMsg string
+		name   string
+	}{
+		{
+			def: EventTriggerDefinition{
+				Contract:      setup.contractAddress,
+				LogPredicates: []LogPredicate{matchOne, matchTwo, matchThree, matchSix},
+			},
+			match:  true,
+			errMsg: "",
+			name:   "match one, two, three and six",
+		},
+		{
+			def: EventTriggerDefinition{
+				Contract:      setup.contractAddress,
+				LogPredicates: []LogPredicate{matchFour},
+			},
+			match:  true,
+			errMsg: "",
+			name:   "match four",
+		},
+		{
+			def: EventTriggerDefinition{
+				Contract:      setup.contractAddress,
+				LogPredicates: []LogPredicate{matchFour, matchSix},
+			},
+			match:  true,
+			errMsg: "",
+			name:   "match four and six",
+		},
+		{
+			def: EventTriggerDefinition{
+				Contract:      setup.contractAddress,
+				LogPredicates: []LogPredicate{matchSix, matchSix, matchSix},
+			},
+			match:  true,
+			errMsg: "",
+			// Note: this is legal, although not practical
+			name: "match tripplicated six",
+		},
+		{
+			def: EventTriggerDefinition{
+				Contract:      setup.contractAddress,
+				LogPredicates: []LogPredicate{notQuiteMatchFour},
+			},
+			match:  false,
+			errMsg: "",
+			name:   "string prefix should not match whole string",
+		},
+		{
+			def: EventTriggerDefinition{
+				Contract:      setup.contractAddress,
+				LogPredicates: []LogPredicate{dontMatchFour, matchFour},
+			},
+			match:  false,
+			errMsg: "",
+			name:   "match four and dont match four",
+		},
+		{
+			def: EventTriggerDefinition{
+				Contract: setup.contractAddress,
+				LogPredicates: []LogPredicate{
+					{
+						LogValueRef: LogValueRef{Offset: 5},
+						ValuePredicate: ValuePredicate{
+							Op:      UintEq,
+							IntArgs: []*big.Int{five},
+						},
+					},
+				},
+			},
+			match:  true,
+			errMsg: "",
+			name:   "match five EQ",
+		},
+		{
+			def: EventTriggerDefinition{
+				Contract: setup.contractAddress,
+				LogPredicates: []LogPredicate{
+					{
+						LogValueRef: LogValueRef{Offset: 5},
+						ValuePredicate: ValuePredicate{
+							Op:      UintGte,
+							IntArgs: []*big.Int{five},
+						},
+					},
+				},
+			},
+			match:  true,
+			errMsg: "",
+			name:   "match five GTE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			etd := tt.def
+			err := etd.Validate()
+			assert.NilError(t, err, "did not validate: %v", tt.name)
+
+			encoded := etd.MarshalBytes()
+			decoded := EventTriggerDefinition{}
+			decoded.UnmarshalBytes(encoded)
+			doubleEncoded := decoded.MarshalBytes()
+
+			equal := cmp.DeepEqual(encoded, doubleEncoded)
+			assert.Check(t, equal, "did not survive roundtrip: %v", tt.name)
+			match, err := etd.Match(vLog)
+			assert.NilError(t, err, "error when matching: %v. err: %v", tt.name, err)
+			assert.Equal(t, match, tt.match, "did not match expectation: %v\nlog data:\t%v\nmatch data:\t%v", tt.name, vLog, etd)
+			match, err = decoded.Match(vLog)
+			assert.NilError(t, err, "error when matching from decoded: %v. err: %v", tt.name, err)
+			assert.Equal(t, match, tt.match, "did not match expectation after roundtrip: %v", tt.name)
 		})
 	}
 }

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -1937,51 +1937,50 @@ func TestLogValueRefEncodeRLP(t *testing.T) {
 		{
 			name:     "topic reference - offset 0",
 			ref:      LogValueRef{Offset: 0},
-			expected: []byte{0x80, 0x80}, // RLP encoding of uint64(0)
+			expected: []byte{0xc2, 0x80, 0x80}, // RLP encoding of uint64(0)
 		},
 		{
 			name:     "topic reference - offset 3",
 			ref:      LogValueRef{Offset: 3},
-			expected: []byte{0x80, 0x03}, // RLP encoding of uint64(3)
+			expected: []byte{0xc2, 0x80, 0x03}, // RLP encoding of uint64(3)
 		},
 		{
 			name:     "data reference - offset 4",
 			ref:      LogValueRef{Offset: 4},
-			expected: []byte{0x80, 0x04}, // RLP encoding of uint64(4)
+			expected: []byte{0xc2, 0x80, 0x04}, // RLP encoding of uint64(4)
 		},
 		{
 			name:     "data reference - offset 5",
 			ref:      LogValueRef{Offset: 5},
-			expected: []byte{0x80, 0x05}, // RLP encoding of uint64(5)
+			expected: []byte{0xc2, 0x80, 0x05}, // RLP encoding of uint64(5)
 		},
 		{
 			name:     "data reference - offset 10",
 			ref:      LogValueRef{Offset: 10},
-			expected: []byte{0x80, 0x0a}, // RLP encoding of uint64(10)
+			expected: []byte{0xc2, 0x80, 0x0a}, // RLP encoding of uint64(10)
 		},
 		{
 			name:     "data reference - offset 10, dynamic",
 			ref:      LogValueRef{Offset: 10, Dynamic: true},
-			expected: []byte{0x01, 0x0a}, // RLP encoding of uint64(10)
+			expected: []byte{0xc2, 0x01, 0x0a}, // RLP encoding of uint64(10)
 		},
 		{
 			name:     "large offset",
 			ref:      LogValueRef{Offset: 1000, Dynamic: false},
-			expected: []byte{0x80, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
+			expected: []byte{0xc4, 0x80, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
 		},
 		{
 			name:     "large offset, dynamic",
 			ref:      LogValueRef{Offset: 1000, Dynamic: true},
-			expected: []byte{0x01, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
+			expected: []byte{0xc4, 0x01, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			err := tt.ref.EncodeRLP(&buf)
+			encoded, err := rlp.EncodeToBytes(tt.ref)
 			assert.NilError(t, err, "EncodeRLP should not fail")
-			assert.DeepEqual(t, tt.expected, buf.Bytes())
+			assert.DeepEqual(t, tt.expected, encoded)
 		})
 	}
 }
@@ -1996,37 +1995,37 @@ func TestLogValueRefDecodeRLP(t *testing.T) {
 	}{
 		{
 			name:     "topic reference - offset 0",
-			encoded:  []byte{0x80, 0x80}, // RLP encoding of uint64(0)
+			encoded:  []byte{0xc2, 0x80, 0x80}, // RLP encoding of uint64(0)
 			expected: LogValueRef{Offset: 0},
 			wantErr:  false,
 		},
 		{
 			name:     "topic reference - offset 3",
-			encoded:  []byte{0x80, 0x03}, // RLP encoding of uint64(3)
+			encoded:  []byte{0xc2, 0x80, 0x03}, // RLP encoding of uint64(3)
 			expected: LogValueRef{Offset: 3},
 			wantErr:  false,
 		},
 		{
 			name:     "data reference - offset 4",
-			encoded:  []byte{0x80, 0x04}, // RLP encoding of uint64(4)
+			encoded:  []byte{0xc2, 0x80, 0x04}, // RLP encoding of uint64(4)
 			expected: LogValueRef{Offset: 4},
 			wantErr:  false,
 		},
 		{
 			name:     "data reference - offset 5, dynamic true",
-			encoded:  []byte{0x01, 0x05}, // RLP encoding of uint64(5)
+			encoded:  []byte{0xc2, 0x01, 0x05}, // RLP encoding of uint64(5)
 			expected: LogValueRef{Offset: 5, Dynamic: true},
 			wantErr:  false,
 		},
 		{
 			name:     "data reference - offset 10",
-			encoded:  []byte{0x80, 0x0a}, // RLP encoding of uint64(10)
+			encoded:  []byte{0xc2, 0x80, 0x0a}, // RLP encoding of uint64(10)
 			expected: LogValueRef{Offset: 10},
 			wantErr:  false,
 		},
 		{
 			name:     "large offset",
-			encoded:  []byte{0x80, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
+			encoded:  []byte{0xc4, 0x80, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
 			expected: LogValueRef{Offset: 1000},
 			wantErr:  false,
 		},
@@ -2034,19 +2033,19 @@ func TestLogValueRefDecodeRLP(t *testing.T) {
 			name:    "invalid - empty RLP data",
 			encoded: []byte{},
 			wantErr: true,
-			errMsg:  "failed to decode LogValueRef",
+			errMsg:  "EOF",
 		},
 		{
 			name:    "invalid - malformed RLP",
 			encoded: []byte{0xFF, 0xFF},
 			wantErr: true,
-			errMsg:  "failed to decode LogValueRef",
+			errMsg:  "rlp: value size exceeds available input length",
 		},
 		{
 			name:    "invalid - incomplete list",
-			encoded: []byte{0xc1, 0x04}, // List with only one element
+			encoded: []byte{0xc2, 0x04}, // List with only one element
 			wantErr: true,
-			errMsg:  "LogValueRef can't be a list",
+			errMsg:  "rlp: value size exceeds available input length",
 		},
 	}
 
@@ -2092,16 +2091,18 @@ func TestLogValueRefRLPRoundTrip(t *testing.T) {
 			name: "large values",
 			ref:  LogValueRef{Offset: 65535},
 		},
+		{
+			name: "large values - dynamic",
+			ref:  LogValueRef{Offset: 65535, Dynamic: true},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Encode
-			var buf bytes.Buffer
-			err := tt.ref.EncodeRLP(&buf)
+			encoded, err := rlp.EncodeToBytes(tt.ref)
 			assert.NilError(t, err, "EncodeRLP should not fail")
 
-			encoded := buf.Bytes()
 			assert.Assert(t, len(encoded) > 0, "Encoded data should not be empty")
 
 			// Decode
@@ -2113,10 +2114,9 @@ func TestLogValueRefRLPRoundTrip(t *testing.T) {
 			assert.Equal(t, tt.ref.Offset, decoded.Offset)
 
 			// Encode again and verify consistency
-			var buf2 bytes.Buffer
-			err = decoded.EncodeRLP(&buf2)
+			encoded2, err := rlp.EncodeToBytes(decoded)
 			assert.NilError(t, err, "Second EncodeRLP should not fail")
-			assert.DeepEqual(t, encoded, buf2.Bytes())
+			assert.DeepEqual(t, encoded, encoded2)
 		})
 	}
 }

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -2,22 +2,19 @@ package shutterservice
 
 import (
 	"bytes"
-	"context"
 	"fmt"
-	"log"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	"github.com/ethereum/go-ethereum/rlp"
 	"gotest.tools/assert"
 	"gotest.tools/assert/cmp"
+
+	"github.com/shutter-network/rolling-shutter/rolling-shutter/keyperimpl/shutterservice/help"
 )
 
 func TestOpValidate(t *testing.T) {
@@ -2063,67 +2060,8 @@ func TestLogValueRefRLPRoundTrip(t *testing.T) {
 	}
 }
 
-type Setup struct {
-	backend         backends.SimulatedBackend
-	auth            *bind.TransactOpts
-	contract        *Emitter
-	contractAddress common.Address
-}
-
-func setupBackend(t *testing.T) Setup {
-	t.Helper()
-
-	// create funded genesis account
-	privateKey, err := crypto.GenerateKey()
-	assert.NilError(t, err, "failed to generate private key %v", err)
-
-	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1337))
-	assert.NilError(t, err, "failed to create transactor %v", err)
-
-	balance := new(big.Int)
-	balance.SetString("1000000000000000000000", 10) // 1000 ETH
-	alloc := make(types.GenesisAlloc)
-	alloc[auth.From] = types.Account{Balance: balance}
-
-	// create SimulatedBackend
-	b := simulated.NewBackend(alloc, simulated.WithBlockGasLimit(8000000))
-	backend := backends.SimulatedBackend{
-		Backend: b,
-		Client:  b.Client(),
-	}
-	// deploy Emitter contract
-	// Emitter.go is generated through `make all`
-	contractAddress, _, _, err := DeployEmitter(auth, backend)
-	assert.NilError(t, err, "failed to deploy contract: %v", err)
-	backend.Commit()
-
-	// bind contract
-	contract, err := NewEmitter(contractAddress, backend)
-	assert.NilError(t, err, "failed to bind contract instance to address %v: %v", contractAddress, err)
-
-	return Setup{
-		backend:         backend,
-		auth:            auth,
-		contract:        contract,
-		contractAddress: contractAddress,
-	}
-}
-
-func collectLog(t *testing.T, setup Setup, tx *types.Transaction) (*types.Log, error) {
-	t.Helper()
-	// Commit the block to process the transaction
-	setup.backend.Commit()
-
-	// get Receipt for Logs
-	receipt, err := setup.backend.TransactionReceipt(context.Background(), tx.Hash())
-	if err != nil {
-		log.Fatalf("Failed to get receipt: %v", err)
-	}
-	return receipt.Logs[0], nil
-}
-
 func TestWithEVM(t *testing.T) {
-	setup := setupBackend(t)
+	setup := help.SetupBackend(t)
 
 	one := big.NewInt(1)
 	matchOne := LogPredicate{
@@ -2152,9 +2090,9 @@ func TestWithEVM(t *testing.T) {
 
 	six := []byte("second arg")
 	matchSix := LogPredicate{LogValueRef: LogValueRef{Offset: 6}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{six}}}
-	tx, err := setup.contract.EmitSix(setup.auth, one, two, three, four, five, six)
+	tx, err := setup.Contract.EmitSix(setup.Auth, one, two, three, four, five, six)
 	assert.NilError(t, err, "error creating tx")
-	vLog, err := collectLog(t, setup, tx)
+	vLog, err := help.CollectLog(t, setup, tx)
 	assert.NilError(t, err, "error getting log")
 
 	tests := []struct {
@@ -2165,7 +2103,7 @@ func TestWithEVM(t *testing.T) {
 	}{
 		{
 			def: EventTriggerDefinition{
-				Contract:      setup.contractAddress,
+				Contract:      setup.ContractAddress,
 				LogPredicates: []LogPredicate{matchOne, matchTwo, matchThree, matchSix},
 			},
 			match:  true,
@@ -2174,7 +2112,7 @@ func TestWithEVM(t *testing.T) {
 		},
 		{
 			def: EventTriggerDefinition{
-				Contract:      setup.contractAddress,
+				Contract:      setup.ContractAddress,
 				LogPredicates: []LogPredicate{matchFour},
 			},
 			match:  true,
@@ -2183,7 +2121,7 @@ func TestWithEVM(t *testing.T) {
 		},
 		{
 			def: EventTriggerDefinition{
-				Contract:      setup.contractAddress,
+				Contract:      setup.ContractAddress,
 				LogPredicates: []LogPredicate{matchFour, matchSix},
 			},
 			match:  true,
@@ -2192,7 +2130,7 @@ func TestWithEVM(t *testing.T) {
 		},
 		{
 			def: EventTriggerDefinition{
-				Contract:      setup.contractAddress,
+				Contract:      setup.ContractAddress,
 				LogPredicates: []LogPredicate{matchSix, matchSix, matchSix},
 			},
 			match:  true,
@@ -2202,7 +2140,7 @@ func TestWithEVM(t *testing.T) {
 		},
 		{
 			def: EventTriggerDefinition{
-				Contract:      setup.contractAddress,
+				Contract:      setup.ContractAddress,
 				LogPredicates: []LogPredicate{notQuiteMatchFour},
 			},
 			match:  false,
@@ -2211,7 +2149,7 @@ func TestWithEVM(t *testing.T) {
 		},
 		{
 			def: EventTriggerDefinition{
-				Contract:      setup.contractAddress,
+				Contract:      setup.ContractAddress,
 				LogPredicates: []LogPredicate{dontMatchFour, matchFour},
 			},
 			match:  false,
@@ -2220,7 +2158,7 @@ func TestWithEVM(t *testing.T) {
 		},
 		{
 			def: EventTriggerDefinition{
-				Contract: setup.contractAddress,
+				Contract: setup.ContractAddress,
 				LogPredicates: []LogPredicate{
 					{
 						LogValueRef: LogValueRef{Offset: 5},
@@ -2237,7 +2175,7 @@ func TestWithEVM(t *testing.T) {
 		},
 		{
 			def: EventTriggerDefinition{
-				Contract: setup.contractAddress,
+				Contract: setup.ContractAddress,
 				LogPredicates: []LogPredicate{
 					{
 						LogValueRef: LogValueRef{Offset: 5},

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -1858,6 +1858,10 @@ func TestEventTriggerDefinitionUnmarshalErrors(t *testing.T) {
 			data: []byte{0x99}, // Wrong version
 		},
 		{
+			name: "old version",
+			data: []byte{0x1}, // Old version
+		},
+		{
 			name: "version only, no RLP data",
 			data: []byte{Version},
 		},

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -2065,44 +2065,40 @@ func TestLogValueRefRLPRoundTrip(t *testing.T) {
 
 func TestWithEVM(t *testing.T) {
 	setup := help.SetupBackend(t)
-
 	one := big.NewInt(1)
-	matchOne := LogPredicate{
+	mOne := LogPredicate{
 		LogValueRef:    LogValueRef{Offset: 1},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{Align(one.Bytes())}},
 	}
-
 	two := "two"
-	matchTwo := LogPredicate{
+	mTwo := LogPredicate{
 		LogValueRef: LogValueRef{Offset: 2},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{
 			Align(crypto.Keccak256([]byte("two"))),
 		}},
 	}
-
 	three := common.BytesToAddress(big.NewInt(84).Bytes())
-	matchThree := LogPredicate{
+	mThree := LogPredicate{
 		LogValueRef:    LogValueRef{Offset: 3},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{Align(three[:])}},
 	}
 	four := []byte("first and slightly longer arg that should use more space and if i am right, then this will span multiple words")
-	notQuiteFour := []byte("first and slightly longer arg that should use more space and if ")
-	matchFour := LogPredicate{
+	preFour := []byte("first and slightly longer arg that should use more space and if ")
+	mFoure := LogPredicate{
 		LogValueRef:    LogValueRef{Offset: 4},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{four}},
 	}
-	dontMatchFour := LogPredicate{
+	noMFour := LogPredicate{
 		LogValueRef:    LogValueRef{Offset: 4},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{[]byte("no match")}},
 	}
-	notQuiteMatchFour := LogPredicate{
-		LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{notQuiteFour}},
+	preNotFour := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 4},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{preFour}},
 	}
-
 	five := big.NewInt(42)
-
 	six := []byte("second arg")
-	matchSix := LogPredicate{
+	mSix := LogPredicate{
 		LogValueRef:    LogValueRef{Offset: 6},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{six}},
 	}
@@ -2112,104 +2108,41 @@ func TestWithEVM(t *testing.T) {
 	assert.NilError(t, err, "error getting log")
 
 	tests := []struct {
-		def    EventTriggerDefinition
-		match  bool
-		errMsg string
-		name   string
+		predicates []LogPredicate
+		match      bool
+		name       string
 	}{
+		{predicates: []LogPredicate{mOne, mTwo, mThree, mSix}, match: true, name: "match one, two, three and six"},
+		{predicates: []LogPredicate{mFoure}, match: true, name: "match four"},
+		{predicates: []LogPredicate{mFoure, mSix}, match: true, name: "match four and six"},
 		{
-			def: EventTriggerDefinition{
-				Contract:      setup.ContractAddress,
-				LogPredicates: []LogPredicate{matchOne, matchTwo, matchThree, matchSix},
-			},
-			match:  true,
-			errMsg: "",
-			name:   "match one, two, three and six",
-		},
-		{
-			def: EventTriggerDefinition{
-				Contract:      setup.ContractAddress,
-				LogPredicates: []LogPredicate{matchFour},
-			},
-			match:  true,
-			errMsg: "",
-			name:   "match four",
-		},
-		{
-			def: EventTriggerDefinition{
-				Contract:      setup.ContractAddress,
-				LogPredicates: []LogPredicate{matchFour, matchSix},
-			},
-			match:  true,
-			errMsg: "",
-			name:   "match four and six",
-		},
-		{
-			def: EventTriggerDefinition{
-				Contract:      setup.ContractAddress,
-				LogPredicates: []LogPredicate{matchSix, matchSix, matchSix},
-			},
-			match:  true,
-			errMsg: "",
+			predicates: []LogPredicate{mSix, mSix},
+			match:      true,
 			// Note: this is legal, although not practical
-			name: "match tripplicated six",
+			name: "match duplicate six",
 		},
+		{predicates: []LogPredicate{preNotFour}, match: false, name: "prefix should not match whole"},
+		{predicates: []LogPredicate{noMFour, mFoure}, match: false, name: "mismatch same offset"},
 		{
-			def: EventTriggerDefinition{
-				Contract:      setup.ContractAddress,
-				LogPredicates: []LogPredicate{notQuiteMatchFour},
-			},
-			match:  false,
-			errMsg: "",
-			name:   "string prefix should not match whole string",
-		},
-		{
-			def: EventTriggerDefinition{
-				Contract:      setup.ContractAddress,
-				LogPredicates: []LogPredicate{dontMatchFour, matchFour},
-			},
-			match:  false,
-			errMsg: "",
-			name:   "match four and dont match four",
-		},
-		{
-			def: EventTriggerDefinition{
-				Contract: setup.ContractAddress,
-				LogPredicates: []LogPredicate{
-					{
-						LogValueRef: LogValueRef{Offset: 5},
-						ValuePredicate: ValuePredicate{
-							Op:      UintEq,
-							IntArgs: []*big.Int{five},
-						},
+			predicates: []LogPredicate{
+				{
+					LogValueRef: LogValueRef{Offset: 5},
+					ValuePredicate: ValuePredicate{
+						Op:      UintEq,
+						IntArgs: []*big.Int{five},
 					},
 				},
 			},
-			match:  true,
-			errMsg: "",
-			name:   "match five EQ",
-		},
-		{
-			def: EventTriggerDefinition{
-				Contract: setup.ContractAddress,
-				LogPredicates: []LogPredicate{
-					{
-						LogValueRef: LogValueRef{Offset: 5},
-						ValuePredicate: ValuePredicate{
-							Op:      UintGte,
-							IntArgs: []*big.Int{five},
-						},
-					},
-				},
-			},
-			match:  true,
-			errMsg: "",
-			name:   "match five GTE",
+			match: true,
+			name:  "match five GTE",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			etd := tt.def
+			etd := EventTriggerDefinition{
+				Contract:      setup.ContractAddress,
+				LogPredicates: tt.predicates,
+			}
 			err := etd.Validate()
 			assert.NilError(t, err, "did not validate: %v", tt.name)
 

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -92,6 +92,15 @@ func TestLogValueRefValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "invalid topic reference - offset 3, cannot be dynamic",
+			ref: LogValueRef{
+				Offset:  3,
+				Dynamic: true,
+			},
+			wantErr: true,
+			errMsg:  "topic values (offset < 4) are always fixed size of one word, got offset 3",
+		},
+		{
 			name: "valid topic reference - offset 3",
 			ref: LogValueRef{
 				Offset: 3,
@@ -99,16 +108,18 @@ func TestLogValueRefValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "valid data reference - offset 4",
+			name: "valid data reference - offset 4, dynamic size",
 			ref: LogValueRef{
-				Offset: 4,
+				Offset:  4,
+				Dynamic: true,
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid data reference - offset 5",
+			name: "valid data reference - offset 5, fixed size",
 			ref: LogValueRef{
-				Offset: 5,
+				Offset:  5,
+				Dynamic: false,
 			},
 			wantErr: false,
 		},
@@ -983,11 +994,48 @@ func TestLogValueRefGetValue(t *testing.T) {
 				return result
 			}(),
 		},
-
+		{
+			name: "get two data words (offset 4, dynamic)",
+			ref: LogValueRef{
+				Offset:  4,
+				Dynamic: true,
+			},
+			log: &types.Log{
+				Topics: []common.Hash{
+					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
+				},
+				Data: func() []byte {
+					data := make([]byte, 128)
+					// Encode offset
+					data[31] = 32
+					// Encode length
+					data[63] = 64
+					// First word: 0x1111...1111
+					for i := 0; i < 32; i++ {
+						data[64+i] = 0x11
+					}
+					// Second word: 0x2222...2222
+					for i := 0; i < 32; i++ {
+						data[96+i] = 0x22
+					}
+					return data
+				}(),
+			},
+			want: func() []byte {
+				result := make([]byte, 64)
+				for i := 0; i < 32; i++ {
+					result[i] = 0x11
+				}
+				for i := 32; i < 64; i++ {
+					result[i] = 0x22
+				}
+				return result
+			}(),
+		},
 		{
 			name: "get data beyond log length - zero padded",
 			// Third word, but log only has 2 words
-			ref: LogValueRef{Offset: 6},
+			ref: LogValueRef{Offset: 6, Dynamic: false},
 			log: &types.Log{
 				Topics: []common.Hash{
 					common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
@@ -1738,7 +1786,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 			},
 		},
 		{
-			name: "definition with all operation types",
+			name: "definition with all operation types and one dynamic LogValueRef",
 			definition: EventTriggerDefinition{
 				Contract: contractAddr,
 				LogPredicates: []LogPredicate{
@@ -1783,7 +1831,7 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 						},
 					},
 					{
-						LogValueRef: LogValueRef{Offset: 5},
+						LogValueRef: LogValueRef{Offset: 5, Dynamic: true},
 						ValuePredicate: ValuePredicate{
 							Op:       BytesEq,
 							IntArgs:  []*big.Int{},
@@ -1889,32 +1937,42 @@ func TestLogValueRefEncodeRLP(t *testing.T) {
 		{
 			name:     "topic reference - offset 0",
 			ref:      LogValueRef{Offset: 0},
-			expected: []byte{0x80}, // RLP encoding of uint64(0)
+			expected: []byte{0x80, 0x80}, // RLP encoding of uint64(0)
 		},
 		{
 			name:     "topic reference - offset 3",
 			ref:      LogValueRef{Offset: 3},
-			expected: []byte{0x03}, // RLP encoding of uint64(3)
+			expected: []byte{0x80, 0x03}, // RLP encoding of uint64(3)
 		},
 		{
 			name:     "data reference - offset 4",
 			ref:      LogValueRef{Offset: 4},
-			expected: []byte{0x04}, // RLP encoding of uint64(4)
+			expected: []byte{0x80, 0x04}, // RLP encoding of uint64(4)
 		},
 		{
 			name:     "data reference - offset 5",
 			ref:      LogValueRef{Offset: 5},
-			expected: []byte{0x05}, // RLP encoding of uint64(5)
+			expected: []byte{0x80, 0x05}, // RLP encoding of uint64(5)
 		},
 		{
 			name:     "data reference - offset 10",
 			ref:      LogValueRef{Offset: 10},
-			expected: []byte{0x0a}, // RLP encoding of uint64(10)
+			expected: []byte{0x80, 0x0a}, // RLP encoding of uint64(10)
+		},
+		{
+			name:     "data reference - offset 10, dynamic",
+			ref:      LogValueRef{Offset: 10, Dynamic: true},
+			expected: []byte{0x01, 0x0a}, // RLP encoding of uint64(10)
 		},
 		{
 			name:     "large offset",
-			ref:      LogValueRef{Offset: 1000},
-			expected: []byte{0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
+			ref:      LogValueRef{Offset: 1000, Dynamic: false},
+			expected: []byte{0x80, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
+		},
+		{
+			name:     "large offset, dynamic",
+			ref:      LogValueRef{Offset: 1000, Dynamic: true},
+			expected: []byte{0x01, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
 		},
 	}
 
@@ -1938,37 +1996,37 @@ func TestLogValueRefDecodeRLP(t *testing.T) {
 	}{
 		{
 			name:     "topic reference - offset 0",
-			encoded:  []byte{0x80}, // RLP encoding of uint64(0)
+			encoded:  []byte{0x80, 0x80}, // RLP encoding of uint64(0)
 			expected: LogValueRef{Offset: 0},
 			wantErr:  false,
 		},
 		{
 			name:     "topic reference - offset 3",
-			encoded:  []byte{0x03}, // RLP encoding of uint64(3)
+			encoded:  []byte{0x80, 0x03}, // RLP encoding of uint64(3)
 			expected: LogValueRef{Offset: 3},
 			wantErr:  false,
 		},
 		{
 			name:     "data reference - offset 4",
-			encoded:  []byte{0x04}, // RLP encoding of uint64(4)
+			encoded:  []byte{0x80, 0x04}, // RLP encoding of uint64(4)
 			expected: LogValueRef{Offset: 4},
 			wantErr:  false,
 		},
 		{
-			name:     "data reference - offset 5",
-			encoded:  []byte{0x05}, // RLP encoding of uint64(5)
-			expected: LogValueRef{Offset: 5},
+			name:     "data reference - offset 5, dynamic true",
+			encoded:  []byte{0x01, 0x05}, // RLP encoding of uint64(5)
+			expected: LogValueRef{Offset: 5, Dynamic: true},
 			wantErr:  false,
 		},
 		{
 			name:     "data reference - offset 10",
-			encoded:  []byte{0x0a}, // RLP encoding of uint64(10)
+			encoded:  []byte{0x80, 0x0a}, // RLP encoding of uint64(10)
 			expected: LogValueRef{Offset: 10},
 			wantErr:  false,
 		},
 		{
 			name:     "large offset",
-			encoded:  []byte{0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
+			encoded:  []byte{0x80, 0x82, 0x03, 0xe8}, // RLP encoding of uint64(1000)
 			expected: LogValueRef{Offset: 1000},
 			wantErr:  false,
 		},
@@ -2028,7 +2086,7 @@ func TestLogValueRefRLPRoundTrip(t *testing.T) {
 		},
 		{
 			name: "data reference - multiple words",
-			ref:  LogValueRef{Offset: 5},
+			ref:  LogValueRef{Offset: 5, Dynamic: true},
 		},
 		{
 			name: "large values",
@@ -2085,21 +2143,25 @@ func TestWithEVM(t *testing.T) {
 	four := []byte("first and slightly longer arg that should use more space and if i am right, then this will span multiple words")
 	preFour := []byte("first and slightly longer arg that should use more space and if ")
 	mFour := LogPredicate{
-		LogValueRef:    LogValueRef{Offset: 4},
+		LogValueRef:    LogValueRef{Offset: 4, Dynamic: true},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{four}},
 	}
 	noMFour := LogPredicate{
-		LogValueRef:    LogValueRef{Offset: 4},
+		LogValueRef:    LogValueRef{Offset: 4, Dynamic: true},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{[]byte("no match")}},
 	}
+	inValidFour := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 4, Dynamic: false},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{four}},
+	}
 	preNotFour := LogPredicate{
-		LogValueRef:    LogValueRef{Offset: 4},
+		LogValueRef:    LogValueRef{Offset: 4, Dynamic: true},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{preFour}},
 	}
 	five := big.NewInt(42)
 	six := []byte("second arg")
 	mSix := LogPredicate{
-		LogValueRef:    LogValueRef{Offset: 6},
+		LogValueRef:    LogValueRef{Offset: 6, Dynamic: true},
 		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{six}},
 	}
 	tx, err := setup.Contract.EmitSix(setup.Auth, one, two, three, four, five, six)
@@ -2118,11 +2180,11 @@ func TestWithEVM(t *testing.T) {
 		{
 			predicates: []LogPredicate{mSix, mSix},
 			match:      true,
-			// Note: this is legal, although not practical
-			name: "match duplicate six",
+			name:       "match duplicate six", // Note: this is legal, although not practical
 		},
 		{predicates: []LogPredicate{preNotFour}, match: false, name: "prefix should not match whole"},
 		{predicates: []LogPredicate{noMFour, mFour}, match: false, name: "mismatch same offset"},
+		{predicates: []LogPredicate{inValidFour}, match: false, name: "invalid fourth arg matcher"},
 		{
 			predicates: []LogPredicate{
 				{
@@ -2145,7 +2207,6 @@ func TestWithEVM(t *testing.T) {
 			}
 			err := etd.Validate()
 			assert.NilError(t, err, "did not validate: %v", tt.name)
-
 			encoded := etd.MarshalBytes()
 			decoded := EventTriggerDefinition{}
 			err = decoded.UnmarshalBytes(encoded)

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -1813,20 +1813,23 @@ func TestEventTriggerDefinitionMarshalUnmarshal(t *testing.T) {
 				unmarshaledPredicate := unmarshaled.LogPredicates[i]
 
 				// Compare LogValueRef
-				assert.Equal(t, originalPredicate.LogValueRef.Offset, unmarshaledPredicate.LogValueRef.Offset)
+				assert.Equal(t, originalPredicate.LogValueRef.Offset,
+					unmarshaledPredicate.LogValueRef.Offset)
 
 				// Compare ValuePredicate
 				assert.Equal(t, originalPredicate.ValuePredicate.Op, unmarshaledPredicate.ValuePredicate.Op)
 
 				// Compare IntArgs
-				assert.Equal(t, len(originalPredicate.ValuePredicate.IntArgs), len(unmarshaledPredicate.ValuePredicate.IntArgs))
+				assert.Equal(t, len(originalPredicate.ValuePredicate.IntArgs),
+					len(unmarshaledPredicate.ValuePredicate.IntArgs))
 				for j, originalIntArg := range originalPredicate.ValuePredicate.IntArgs {
 					unmarshaledIntArg := unmarshaledPredicate.ValuePredicate.IntArgs[j]
 					assert.Equal(t, originalIntArg.Cmp(unmarshaledIntArg), 0)
 				}
 
 				// Compare ByteArgs
-				assert.Equal(t, len(originalPredicate.ValuePredicate.ByteArgs), len(unmarshaledPredicate.ValuePredicate.ByteArgs))
+				assert.Equal(t, len(originalPredicate.ValuePredicate.ByteArgs),
+					len(unmarshaledPredicate.ValuePredicate.ByteArgs))
 				for j, originalByteArg := range originalPredicate.ValuePredicate.ByteArgs {
 					unmarshaledByteArg := unmarshaledPredicate.ValuePredicate.ByteArgs[j]
 					assert.DeepEqual(t, originalByteArg, unmarshaledByteArg)
@@ -2071,8 +2074,10 @@ func TestWithEVM(t *testing.T) {
 
 	two := "two"
 	matchTwo := LogPredicate{
-		LogValueRef:    LogValueRef{Offset: 2},
-		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{Align(crypto.Keccak256([]byte("two")))}},
+		LogValueRef: LogValueRef{Offset: 2},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{
+			Align(crypto.Keccak256([]byte("two"))),
+		}},
 	}
 
 	three := common.BytesToAddress(big.NewInt(84).Bytes())
@@ -2082,14 +2087,25 @@ func TestWithEVM(t *testing.T) {
 	}
 	four := []byte("first and slightly longer arg that should use more space and if i am right, then this will span multiple words")
 	notQuiteFour := []byte("first and slightly longer arg that should use more space and if ")
-	matchFour := LogPredicate{LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{four}}}
-	dontMatchFour := LogPredicate{LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{[]byte("no match")}}}
-	notQuiteMatchFour := LogPredicate{LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{notQuiteFour}}}
+	matchFour := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 4},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{four}},
+	}
+	dontMatchFour := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 4},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{[]byte("no match")}},
+	}
+	notQuiteMatchFour := LogPredicate{
+		LogValueRef: LogValueRef{Offset: 4}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{notQuiteFour}},
+	}
 
 	five := big.NewInt(42)
 
 	six := []byte("second arg")
-	matchSix := LogPredicate{LogValueRef: LogValueRef{Offset: 6}, ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{six}}}
+	matchSix := LogPredicate{
+		LogValueRef:    LogValueRef{Offset: 6},
+		ValuePredicate: ValuePredicate{Op: BytesEq, ByteArgs: [][]byte{six}},
+	}
 	tx, err := setup.Contract.EmitSix(setup.Auth, one, two, three, four, five, six)
 	assert.NilError(t, err, "error creating tx")
 	vLog, err := help.CollectLog(t, setup, tx)
@@ -2199,7 +2215,8 @@ func TestWithEVM(t *testing.T) {
 
 			encoded := etd.MarshalBytes()
 			decoded := EventTriggerDefinition{}
-			decoded.UnmarshalBytes(encoded)
+			err = decoded.UnmarshalBytes(encoded)
+			assert.NilError(t, err, "error when roundtrip decoding")
 			doubleEncoded := decoded.MarshalBytes()
 
 			equal := cmp.DeepEqual(encoded, doubleEncoded)

--- a/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtrigger_test.go
@@ -2163,3 +2163,11 @@ func TestWithEVM(t *testing.T) {
 		})
 	}
 }
+
+// aligns []byte to 32 byte.
+func Align(val []byte) []byte {
+	words := (31 + len(val)) / Word
+	x := make([]byte, Word*words)
+	copy(x[len(x)-len(val):], val)
+	return x
+}

--- a/rolling-shutter/keyperimpl/shutterservice/help/Emitter.go
+++ b/rolling-shutter/keyperimpl/shutterservice/help/Emitter.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package shutterservice
+package help
 
 import (
 	"errors"

--- a/rolling-shutter/keyperimpl/shutterservice/help/Emitter.go
+++ b/rolling-shutter/keyperimpl/shutterservice/help/Emitter.go
@@ -31,8 +31,8 @@ var (
 
 // EmitterMetaData contains all meta data concerning the Emitter contract.
 var EmitterMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"five\",\"type\":\"bytes\"}],\"name\":\"Five\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"}],\"name\":\"Four\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"two\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"three\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"five\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"six\",\"type\":\"bytes\"}],\"name\":\"Six\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"newValue\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Two\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"five\",\"type\":\"bytes\"}],\"name\":\"emitFive\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"}],\"name\":\"emitFour\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"two\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"three\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"five\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"six\",\"type\":\"bytes\"}],\"name\":\"emitSix\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"emitTwo\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
-	Bin: "0x608060405234801561001057600080fd5b506108ed806100206000396000f3fe608060405234801561001057600080fd5b506004361061004c5760003560e01c80636995a2d9146100515780637155880d1461006d5780638cc5e89214610089578063f70770e0146100a5575b600080fd5b61006b60048036038101906100669190610381565b6100c1565b005b61008760048036038101906100829190610434565b610104565b005b6100a3600480360381019061009e9190610461565b610140565b005b6100bf60048036038101906100ba91906105e3565b610180565b005b8284867f2778059b9d45e2cd0df03a27bbe3e688dfc48aa15a729c42f39dcd986ebd446185856040516100f592919061074c565b60405180910390a45050505050565b807fce34f015a0e20f2b0daf980b28ed50729e87b993e4d30cca4c3f4da05acbd0ac600560405161013591906107c8565b60405180910390a250565b8183857fd82c9bd67140e94b50e0a62e800c51428267b0cd733573daaafad26b62c05afb8460405161017291906107e3565b60405180910390a450505050565b8373ffffffffffffffffffffffffffffffffffffffff16856040516101a5919061084c565b6040518091039020877f1c49d7caedaa8e8be0f2ef7b3c285ccaef7eac5a7fe6b427cbe7e7d8ad3070548686866040516101e193929190610872565b60405180910390a4505050505050565b6000604051905090565b600080fd5b600080fd5b6000819050919050565b61021881610205565b811461022357600080fd5b50565b6000813590506102358161020f565b92915050565b600080fd5b600080fd5b6000601f19601f8301169050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b61028e82610245565b810181811067ffffffffffffffff821117156102ad576102ac610256565b5b80604052505050565b60006102c06101f1565b90506102cc8282610285565b919050565b600067ffffffffffffffff8211156102ec576102eb610256565b5b6102f582610245565b9050602081019050919050565b82818337600083830152505050565b600061032461031f846102d1565b6102b6565b9050828152602081018484840111156103405761033f610240565b5b61034b848285610302565b509392505050565b600082601f8301126103685761036761023b565b5b8135610378848260208601610311565b91505092915050565b600080600080600060a0868803121561039d5761039c6101fb565b5b60006103ab88828901610226565b95505060206103bc88828901610226565b94505060406103cd88828901610226565b935050606086013567ffffffffffffffff8111156103ee576103ed610200565b5b6103fa88828901610353565b925050608086013567ffffffffffffffff81111561041b5761041a610200565b5b61042788828901610353565b9150509295509295909350565b60006020828403121561044a576104496101fb565b5b600061045884828501610226565b91505092915050565b6000806000806080858703121561047b5761047a6101fb565b5b600061048987828801610226565b945050602061049a87828801610226565b93505060406104ab87828801610226565b925050606085013567ffffffffffffffff8111156104cc576104cb610200565b5b6104d887828801610353565b91505092959194509250565b600067ffffffffffffffff8211156104ff576104fe610256565b5b61050882610245565b9050602081019050919050565b6000610528610523846104e4565b6102b6565b90508281526020810184848401111561054457610543610240565b5b61054f848285610302565b509392505050565b600082601f83011261056c5761056b61023b565b5b813561057c848260208601610515565b91505092915050565b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b60006105b082610585565b9050919050565b6105c0816105a5565b81146105cb57600080fd5b50565b6000813590506105dd816105b7565b92915050565b60008060008060008060c08789031215610600576105ff6101fb565b5b600061060e89828a01610226565b965050602087013567ffffffffffffffff81111561062f5761062e610200565b5b61063b89828a01610557565b955050604061064c89828a016105ce565b945050606087013567ffffffffffffffff81111561066d5761066c610200565b5b61067989828a01610353565b935050608061068a89828a01610226565b92505060a087013567ffffffffffffffff8111156106ab576106aa610200565b5b6106b789828a01610353565b9150509295509295509295565b600081519050919050565b600082825260208201905092915050565b60005b838110156106fe5780820151818401526020810190506106e3565b8381111561070d576000848401525b50505050565b600061071e826106c4565b61072881856106cf565b93506107388185602086016106e0565b61074181610245565b840191505092915050565b600060408201905081810360008301526107668185610713565b9050818103602083015261077a8184610713565b90509392505050565b6000819050919050565b6000819050919050565b60006107b26107ad6107a884610783565b61078d565b610205565b9050919050565b6107c281610797565b82525050565b60006020820190506107dd60008301846107b9565b92915050565b600060208201905081810360008301526107fd8184610713565b905092915050565b600081519050919050565b600081905092915050565b600061082682610805565b6108308185610810565b93506108408185602086016106e0565b80840191505092915050565b6000610858828461081b565b915081905092915050565b61086c81610205565b82525050565b6000606082019050818103600083015261088c8186610713565b905061089b6020830185610863565b81810360408301526108ad8184610713565b905094935050505056fea2646970667358221220848f06dbefbfd7023244910f585f43334b07207284d4f6541eb16b4b0073fa8964736f6c63430008090033",
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"five\",\"type\":\"bytes\"}],\"name\":\"Five\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"}],\"name\":\"Four\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"two\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"}],\"name\":\"SingleIdx\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"string\",\"name\":\"two\",\"type\":\"string\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"three\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"five\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"six\",\"type\":\"bytes\"}],\"name\":\"Six\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"newValue\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Two\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"five\",\"type\":\"bytes\"}],\"name\":\"emitFive\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"two\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"}],\"name\":\"emitFour\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"two\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"three\",\"type\":\"uint256\"}],\"name\":\"emitSingleIdx\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"one\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"two\",\"type\":\"string\"},{\"internalType\":\"address\",\"name\":\"three\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"four\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"five\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"six\",\"type\":\"bytes\"}],\"name\":\"emitSix\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"emitTwo\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x608060405234801561001057600080fd5b506109f2806100206000396000f3fe608060405234801561001057600080fd5b50600436106100575760003560e01c80636995a2d91461005c5780637155880d146100785780638cc5e89214610094578063bb1c31ec146100b0578063f70770e0146100cc575b600080fd5b610076600480360381019061007191906103e7565b6100e8565b005b610092600480360381019061008d919061049a565b61012b565b005b6100ae60048036038101906100a991906104c7565b610167565b005b6100ca60048036038101906100c5919061054a565b6101a7565b005b6100e660048036038101906100e191906106b8565b6101e6565b005b8284867f2778059b9d45e2cd0df03a27bbe3e688dfc48aa15a729c42f39dcd986ebd4461858560405161011c929190610821565b60405180910390a45050505050565b807fce34f015a0e20f2b0daf980b28ed50729e87b993e4d30cca4c3f4da05acbd0ac600560405161015c919061089d565b60405180910390a250565b8183857fd82c9bd67140e94b50e0a62e800c51428267b0cd733573daaafad26b62c05afb8460405161019991906108b8565b60405180910390a450505050565b827f118f15bfd27a002429cfe56dc0757c904b3e8c0535f4f54771d8b184ecdf381483836040516101d99291906108e9565b60405180910390a2505050565b8373ffffffffffffffffffffffffffffffffffffffff168560405161020b9190610960565b6040518091039020877f1c49d7caedaa8e8be0f2ef7b3c285ccaef7eac5a7fe6b427cbe7e7d8ad30705486868660405161024793929190610977565b60405180910390a4505050505050565b6000604051905090565b600080fd5b600080fd5b6000819050919050565b61027e8161026b565b811461028957600080fd5b50565b60008135905061029b81610275565b92915050565b600080fd5b600080fd5b6000601f19601f8301169050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6102f4826102ab565b810181811067ffffffffffffffff82111715610313576103126102bc565b5b80604052505050565b6000610326610257565b905061033282826102eb565b919050565b600067ffffffffffffffff821115610352576103516102bc565b5b61035b826102ab565b9050602081019050919050565b82818337600083830152505050565b600061038a61038584610337565b61031c565b9050828152602081018484840111156103a6576103a56102a6565b5b6103b1848285610368565b509392505050565b600082601f8301126103ce576103cd6102a1565b5b81356103de848260208601610377565b91505092915050565b600080600080600060a0868803121561040357610402610261565b5b60006104118882890161028c565b95505060206104228882890161028c565b94505060406104338882890161028c565b935050606086013567ffffffffffffffff81111561045457610453610266565b5b610460888289016103b9565b925050608086013567ffffffffffffffff81111561048157610480610266565b5b61048d888289016103b9565b9150509295509295909350565b6000602082840312156104b0576104af610261565b5b60006104be8482850161028c565b91505092915050565b600080600080608085870312156104e1576104e0610261565b5b60006104ef8782880161028c565b94505060206105008782880161028c565b93505060406105118782880161028c565b925050606085013567ffffffffffffffff81111561053257610531610266565b5b61053e878288016103b9565b91505092959194509250565b60008060006060848603121561056357610562610261565b5b60006105718682870161028c565b935050602084013567ffffffffffffffff81111561059257610591610266565b5b61059e868287016103b9565b92505060406105af8682870161028c565b9150509250925092565b600067ffffffffffffffff8211156105d4576105d36102bc565b5b6105dd826102ab565b9050602081019050919050565b60006105fd6105f8846105b9565b61031c565b905082815260208101848484011115610619576106186102a6565b5b610624848285610368565b509392505050565b600082601f830112610641576106406102a1565b5b81356106518482602086016105ea565b91505092915050565b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b60006106858261065a565b9050919050565b6106958161067a565b81146106a057600080fd5b50565b6000813590506106b28161068c565b92915050565b60008060008060008060c087890312156106d5576106d4610261565b5b60006106e389828a0161028c565b965050602087013567ffffffffffffffff81111561070457610703610266565b5b61071089828a0161062c565b955050604061072189828a016106a3565b945050606087013567ffffffffffffffff81111561074257610741610266565b5b61074e89828a016103b9565b935050608061075f89828a0161028c565b92505060a087013567ffffffffffffffff8111156107805761077f610266565b5b61078c89828a016103b9565b9150509295509295509295565b600081519050919050565b600082825260208201905092915050565b60005b838110156107d35780820151818401526020810190506107b8565b838111156107e2576000848401525b50505050565b60006107f382610799565b6107fd81856107a4565b935061080d8185602086016107b5565b610816816102ab565b840191505092915050565b6000604082019050818103600083015261083b81856107e8565b9050818103602083015261084f81846107e8565b90509392505050565b6000819050919050565b6000819050919050565b600061088761088261087d84610858565b610862565b61026b565b9050919050565b6108978161086c565b82525050565b60006020820190506108b2600083018461088e565b92915050565b600060208201905081810360008301526108d281846107e8565b905092915050565b6108e38161026b565b82525050565b6000604082019050818103600083015261090381856107e8565b905061091260208301846108da565b9392505050565b600081519050919050565b600081905092915050565b600061093a82610919565b6109448185610924565b93506109548185602086016107b5565b80840191505092915050565b600061096c828461092f565b915081905092915050565b6000606082019050818103600083015261099181866107e8565b90506109a060208301856108da565b81810360408301526109b281846107e8565b905094935050505056fea2646970667358221220095412f10dd044a1de6fe1692f95175a761ae75806a97261993a8ab82c278d7d64736f6c63430008090033",
 }
 
 // EmitterABI is the input ABI used to generate the binding from.
@@ -242,6 +242,27 @@ func (_Emitter *EmitterSession) EmitFour(one *big.Int, two *big.Int, three *big.
 // Solidity: function emitFour(uint256 one, uint256 two, uint256 three, bytes four) returns()
 func (_Emitter *EmitterTransactorSession) EmitFour(one *big.Int, two *big.Int, three *big.Int, four []byte) (*types.Transaction, error) {
 	return _Emitter.Contract.EmitFour(&_Emitter.TransactOpts, one, two, three, four)
+}
+
+// EmitSingleIdx is a paid mutator transaction binding the contract method 0xbb1c31ec.
+//
+// Solidity: function emitSingleIdx(uint256 one, bytes two, uint256 three) returns()
+func (_Emitter *EmitterTransactor) EmitSingleIdx(opts *bind.TransactOpts, one *big.Int, two []byte, three *big.Int) (*types.Transaction, error) {
+	return _Emitter.contract.Transact(opts, "emitSingleIdx", one, two, three)
+}
+
+// EmitSingleIdx is a paid mutator transaction binding the contract method 0xbb1c31ec.
+//
+// Solidity: function emitSingleIdx(uint256 one, bytes two, uint256 three) returns()
+func (_Emitter *EmitterSession) EmitSingleIdx(one *big.Int, two []byte, three *big.Int) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitSingleIdx(&_Emitter.TransactOpts, one, two, three)
+}
+
+// EmitSingleIdx is a paid mutator transaction binding the contract method 0xbb1c31ec.
+//
+// Solidity: function emitSingleIdx(uint256 one, bytes two, uint256 three) returns()
+func (_Emitter *EmitterTransactorSession) EmitSingleIdx(one *big.Int, two []byte, three *big.Int) (*types.Transaction, error) {
+	return _Emitter.Contract.EmitSingleIdx(&_Emitter.TransactOpts, one, two, three)
 }
 
 // EmitSix is a paid mutator transaction binding the contract method 0xf70770e0.
@@ -603,6 +624,150 @@ func (_Emitter *EmitterFilterer) WatchFour(opts *bind.WatchOpts, sink chan<- *Em
 func (_Emitter *EmitterFilterer) ParseFour(log types.Log) (*EmitterFour, error) {
 	event := new(EmitterFour)
 	if err := _Emitter.contract.UnpackLog(event, "Four", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EmitterSingleIdxIterator is returned from FilterSingleIdx and is used to iterate over the raw logs and unpacked data for SingleIdx events raised by the Emitter contract.
+type EmitterSingleIdxIterator struct {
+	Event *EmitterSingleIdx // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EmitterSingleIdxIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EmitterSingleIdx)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EmitterSingleIdx)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EmitterSingleIdxIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EmitterSingleIdxIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EmitterSingleIdx represents a SingleIdx event raised by the Emitter contract.
+type EmitterSingleIdx struct {
+	One   *big.Int
+	Two   []byte
+	Three *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterSingleIdx is a free log retrieval operation binding the contract event 0x118f15bfd27a002429cfe56dc0757c904b3e8c0535f4f54771d8b184ecdf3814.
+//
+// Solidity: event SingleIdx(uint256 indexed one, bytes two, uint256 three)
+func (_Emitter *EmitterFilterer) FilterSingleIdx(opts *bind.FilterOpts, one []*big.Int) (*EmitterSingleIdxIterator, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+
+	logs, sub, err := _Emitter.contract.FilterLogs(opts, "SingleIdx", oneRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EmitterSingleIdxIterator{contract: _Emitter.contract, event: "SingleIdx", logs: logs, sub: sub}, nil
+}
+
+// WatchSingleIdx is a free log subscription operation binding the contract event 0x118f15bfd27a002429cfe56dc0757c904b3e8c0535f4f54771d8b184ecdf3814.
+//
+// Solidity: event SingleIdx(uint256 indexed one, bytes two, uint256 three)
+func (_Emitter *EmitterFilterer) WatchSingleIdx(opts *bind.WatchOpts, sink chan<- *EmitterSingleIdx, one []*big.Int) (event.Subscription, error) {
+	var oneRule []interface{}
+	for _, oneItem := range one {
+		oneRule = append(oneRule, oneItem)
+	}
+
+	logs, sub, err := _Emitter.contract.WatchLogs(opts, "SingleIdx", oneRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EmitterSingleIdx)
+				if err := _Emitter.contract.UnpackLog(event, "SingleIdx", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSingleIdx is a log parse operation binding the contract event 0x118f15bfd27a002429cfe56dc0757c904b3e8c0535f4f54771d8b184ecdf3814.
+//
+// Solidity: event SingleIdx(uint256 indexed one, bytes two, uint256 three)
+func (_Emitter *EmitterFilterer) ParseSingleIdx(log types.Log) (*EmitterSingleIdx, error) {
+	event := new(EmitterSingleIdx)
+	if err := _Emitter.contract.UnpackLog(event, "SingleIdx", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/rolling-shutter/keyperimpl/shutterservice/help/Emitter.sol
+++ b/rolling-shutter/keyperimpl/shutterservice/help/Emitter.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Emitter {
+    event Two(uint256 indexed newValue, uint256 value);
+    event Four(
+        uint256 indexed one,
+        uint256 indexed two,
+        uint256 indexed three,
+        bytes four
+    );
+    event Five(
+        uint256 indexed one,
+        uint256 indexed two,
+        uint256 indexed three,
+        bytes four,
+        bytes five
+    );
+    event Six(
+        uint256 indexed one,
+        string indexed two,
+        address indexed three,
+        bytes four,
+        uint256 five,
+        bytes six
+    );
+
+    function emitTwo(uint256 value) public {
+        emit Two(value, 5);
+    }
+
+    function emitFour(
+        uint256 one,
+        uint256 two,
+        uint256 three,
+        bytes memory four
+    ) public {
+        emit Four(one, two, three, four);
+    }
+
+    function emitFive(
+        uint256 one,
+        uint256 two,
+        uint256 three,
+        bytes memory four,
+        bytes memory five
+    ) public {
+        emit Five(one, two, three, four, five);
+    }
+
+    function emitSix(
+        uint256 one,
+        string memory two,
+        address three,
+        bytes memory four,
+        uint256 five,
+        bytes memory six
+    ) public {
+        emit Six(one, two, three, four, five, six);
+    }
+}

--- a/rolling-shutter/keyperimpl/shutterservice/help/Emitter.sol
+++ b/rolling-shutter/keyperimpl/shutterservice/help/Emitter.sol
@@ -25,6 +25,16 @@ contract Emitter {
         bytes six
     );
 
+    event SingleIdx(uint256 indexed one, bytes two, uint256 three);
+
+    function emitSingleIdx(
+        uint256 one,
+        bytes memory two,
+        uint256 three
+    ) public {
+        emit SingleIdx(one, two, three);
+    }
+
     function emitTwo(uint256 value) public {
         emit Two(value, 5);
     }

--- a/rolling-shutter/keyperimpl/shutterservice/help/Makefile
+++ b/rolling-shutter/keyperimpl/shutterservice/help/Makefile
@@ -20,12 +20,9 @@ $(CONTRACT).go: $(CONTRACT).json
 	@echo "Generating Go bindings..."
 	$(ABIGEN) \
 		--combined-json $(CONTRACT).json \
-		--pkg shutterservice \
-		--out ../$(CONTRACT).go
+		--pkg help \
+		--out $(CONTRACT).go
 
 # Clean generated files
 clean:
-	rm -f $(CONTRACT).json ../$(CONTRACT).go
-
-test:
-	go test -run TestMyEVM
+	rm -f $(CONTRACT).json $(CONTRACT).go

--- a/rolling-shutter/keyperimpl/shutterservice/help/Makefile
+++ b/rolling-shutter/keyperimpl/shutterservice/help/Makefile
@@ -1,0 +1,31 @@
+# Makefile for Emitter.sol
+
+.PHONY: all clean test
+
+# Variables
+SOLC := solc
+ABIGEN := abigen
+CONTRACT := Emitter
+
+# Default target: generate Go bindings
+all: $(CONTRACT).go
+
+# Compile Solidity to ABI and Binary
+$(CONTRACT).json: $(CONTRACT).sol
+	@echo "Compiling Solidity contract..."
+	$(SOLC) --combined-json abi,bin $(CONTRACT).sol > $(CONTRACT).json
+
+# Generate Go bindings using abigen
+$(CONTRACT).go: $(CONTRACT).json
+	@echo "Generating Go bindings..."
+	$(ABIGEN) \
+		--combined-json $(CONTRACT).json \
+		--pkg shutterservice \
+		--out ../$(CONTRACT).go
+
+# Clean generated files
+clean:
+	rm -f $(CONTRACT).json ../$(CONTRACT).go
+
+test:
+	go test -run TestMyEVM

--- a/rolling-shutter/keyperimpl/shutterservice/help/evm.go
+++ b/rolling-shutter/keyperimpl/shutterservice/help/evm.go
@@ -2,7 +2,7 @@ package help
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -69,7 +69,7 @@ func CollectLog(t *testing.T, setup Setup, tx *types.Transaction) (*types.Log, e
 	// get Receipt for Logs
 	receipt, err := setup.Backend.TransactionReceipt(context.Background(), tx.Hash())
 	if err != nil {
-		log.Fatalf("Failed to get receipt: %v", err)
+		return nil, fmt.Errorf("failed to get receipt: %v", err)
 	}
 	return receipt.Logs[0], nil
 }

--- a/rolling-shutter/keyperimpl/shutterservice/help/evm.go
+++ b/rolling-shutter/keyperimpl/shutterservice/help/evm.go
@@ -1,0 +1,75 @@
+package help
+
+import (
+	"context"
+	"log"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"gotest.tools/assert"
+)
+
+type Setup struct {
+	Backend         backends.SimulatedBackend
+	Auth            *bind.TransactOpts
+	Contract        *Emitter
+	ContractAddress common.Address
+}
+
+func SetupBackend(t *testing.T) Setup {
+	t.Helper()
+
+	// create funded genesis account
+	privateKey, err := crypto.GenerateKey()
+	assert.NilError(t, err, "failed to generate private key %v", err)
+
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1337))
+	assert.NilError(t, err, "failed to create transactor %v", err)
+
+	balance := new(big.Int)
+	balance.SetString("1000000000000000000000", 10) // 1000 ETH
+	alloc := make(types.GenesisAlloc)
+	alloc[auth.From] = types.Account{Balance: balance}
+
+	// create SimulatedBackend
+	b := simulated.NewBackend(alloc, simulated.WithBlockGasLimit(8000000))
+	backend := backends.SimulatedBackend{
+		Backend: b,
+		Client:  b.Client(),
+	}
+	// deploy Emitter contract
+	// Emitter.go is generated through `make all`
+	contractAddress, _, _, err := DeployEmitter(auth, backend)
+	assert.NilError(t, err, "failed to deploy contract: %v", err)
+	backend.Commit()
+
+	// bind contract
+	contract, err := NewEmitter(contractAddress, backend)
+	assert.NilError(t, err, "failed to bind contract instance to address %v: %v", contractAddress, err)
+
+	return Setup{
+		Backend:         backend,
+		Auth:            auth,
+		Contract:        contract,
+		ContractAddress: contractAddress,
+	}
+}
+
+func CollectLog(t *testing.T, setup Setup, tx *types.Transaction) (*types.Log, error) {
+	t.Helper()
+	// Commit the block to process the transaction
+	setup.Backend.Commit()
+
+	// get Receipt for Logs
+	receipt, err := setup.Backend.TransactionReceipt(context.Background(), tx.Hash())
+	if err != nil {
+		log.Fatalf("Failed to get receipt: %v", err)
+	}
+	return receipt.Logs[0], nil
+}


### PR DESCRIPTION
There was an incorrect assumption when defining event trigger
matches on "complex" data values (i.e. those, spanning multiple data
words: bytes, string, ...).

Previously, we encoded the `Length` in the trigger definition and
expected to read that much from log data in order to match. However,
this would break, when the actual log data had a different alignment
(due to previous non-targeted arguments).

Instead we could remove `Length` from `LogValueRef`,
and introduce a `Dynamic` flag, to indicate fields for which we want to rely 
on the encoded length in the event data (see
https://docs.soliditylang.org/en/latest/abi-spec.html) at the specified
`Offset`.

We added more tests, that use a `SimulatedBackend` EVM to make sure, we
can properly decode and match actual EVM generated logs.

Since `Length` is no longer defined, we had to adjust some tests and
remove some edge case checks that no longer apply.

This increments the `Version` byte of event trigger definition RLP encoding to `0x02`.

Relates to https://github.com/shutter-network/shutter-api/issues/84
Critical for: https://github.com/shutter-network/shutter-api/issues/110 