### PR TITLE
fix: fork height definition persistence

### DIFF
--- a/rolling-shutter/app/app.go
+++ b/rolling-shutter/app/app.go
@@ -106,14 +106,7 @@ func LoadShutterAppFromFile(gobpath string) (ShutterApp, error) {
 		if err != nil {
 			return shapp, err
 		}
-		// Old versions of ShutterApp were initialized with a genesis file
-		// that did not contain ForkHeights and thus do not have them set
-		// either. For backwards compatibility, we set them to all disabled
-		// here (but they will likely be overridden by chain id specific
-		// overrides).
-		if shapp.ForkHeights == nil {
-			shapp.ForkHeights = NewForkHeightsAllDisabled()
-		}
+		shapp.ForkHeights = migrateForkHeights(shapp.ForkHeights)
 		log.Info().
 			Str("file", gobpath).
 			Time("last-saved", shapp.LastSaved).
@@ -125,6 +118,28 @@ func LoadShutterAppFromFile(gobpath string) (ShutterApp, error) {
 	shapp.Gobpath = gobpath
 	shapp.LastSaved = time.Now() // Do not persist immediately after starting
 	return shapp, nil
+}
+
+// migrateForkHeights applies backwards-compatibility migrations for fork
+// height state loaded from persisted app state or genesis.
+func migrateForkHeights(forkHeights *ForkHeights) *ForkHeights {
+	if forkHeights == nil {
+		return NewForkHeightsAllDisabled()
+	}
+	if forkHeights.CheckInUpdateNew == (ForkHeight{}) && forkHeights.CheckInUpdate != nil {
+		log.Info().
+			Int64("check-in-update-height", *forkHeights.CheckInUpdate).
+			Msg("migrating legacy fork height checkInUpdate to checkInUpdateNew")
+		forkHeights.CheckInUpdateNew = ForkHeight{
+			Enabled: true,
+			Height:  *forkHeights.CheckInUpdate,
+		}
+	}
+	if forkHeights.CheckInUpdate != nil {
+		log.Info().Msg("clearing legacy fork height checkInUpdate after migration")
+		forkHeights.CheckInUpdate = nil
+	}
+	return forkHeights
 }
 
 // checkConfig checks if the given BatchConfig could be added.
@@ -227,14 +242,7 @@ func (app *ShutterApp) InitChain(req abcitypes.RequestInitChain) abcitypes.Respo
 		log.Fatal().Err(err).Msg("cannot unmarshal genesis app state")
 	}
 
-	// ForkHeights are taken from the genesis state. For backwards compatibility
-	// with older genesis files that do not specify ForkHeights, we initialize
-	// them with all forks disabled (note however that they will likely be
-	// superseded by chain id based overrides).
-	app.ForkHeights = genesisState.ForkHeights
-	if app.ForkHeights == nil {
-		app.ForkHeights = NewForkHeightsAllDisabled()
-	}
+	app.ForkHeights = migrateForkHeights(genesisState.ForkHeights)
 
 	bc := BatchConfig{
 		ActivationBlockNumber: 0,

--- a/rolling-shutter/app/app_test.go
+++ b/rolling-shutter/app/app_test.go
@@ -99,3 +99,47 @@ func TestGobDKG(t *testing.T) {
 
 	shtest.EnsureGobable(t, &dkg, new(DKGInstance))
 }
+
+func TestMigrateForkHeights(t *testing.T) {
+	t.Run("fork heights nil defaults to all disabled", func(t *testing.T) {
+		got := migrateForkHeights(nil)
+		assert.Assert(t, is.DeepEqual(got, NewForkHeightsAllDisabled()))
+	})
+
+	t.Run("legacy CheckInUpdate migrates to CheckInUpdateNew", func(t *testing.T) {
+		legacyHeight := int64(123)
+		got := migrateForkHeights(&ForkHeights{CheckInUpdate: &legacyHeight})
+
+		assert.Assert(t, got.CheckInUpdate == nil)
+		assert.Assert(t, is.DeepEqual(got.CheckInUpdateNew, ForkHeight{Enabled: true, Height: 123}))
+	})
+
+	t.Run("legacy CheckInUpdate zero migrates to enabled genesis fork", func(t *testing.T) {
+		legacyHeight := int64(0)
+		got := migrateForkHeights(&ForkHeights{CheckInUpdate: &legacyHeight})
+
+		assert.Assert(t, got.CheckInUpdate == nil)
+		assert.Assert(t, is.DeepEqual(got.CheckInUpdateNew, ForkHeight{Enabled: true, Height: 0}))
+	})
+
+	t.Run("CheckInUpdateNew is preserved and CheckInUpdate is unset", func(t *testing.T) {
+		legacyHeight := int64(999)
+		expected := ForkHeight{Enabled: true, Height: 42}
+		got := migrateForkHeights(&ForkHeights{
+			CheckInUpdate:    &legacyHeight,
+			CheckInUpdateNew: expected,
+		})
+
+		assert.Assert(t, got.CheckInUpdate == nil)
+		assert.Assert(t, is.DeepEqual(got.CheckInUpdateNew, expected))
+	})
+
+	t.Run("idempotent when CheckInUpdate is unset", func(t *testing.T) {
+		initial := &ForkHeights{CheckInUpdateNew: ForkHeight{Enabled: true, Height: 42}}
+
+		first := migrateForkHeights(initial)
+		second := migrateForkHeights(first)
+
+		assert.Assert(t, is.DeepEqual(second, first))
+	})
+}

--- a/rolling-shutter/app/forks.go
+++ b/rolling-shutter/app/forks.go
@@ -30,7 +30,10 @@ func uint64Ptr(value uint64) *uint64 {
 func NewForkHeightsAllEnabled() *ForkHeights {
 	zero := int64(0)
 	return &ForkHeights{
-		CheckInUpdate: &zero,
+		CheckInUpdateNew: ForkHeight{
+			Enabled: true,
+			Height:  zero,
+		},
 	}
 }
 
@@ -38,7 +41,10 @@ func NewForkHeightsAllEnabled() *ForkHeights {
 // are set to disabled.
 func NewForkHeightsAllDisabled() *ForkHeights {
 	return &ForkHeights{
-		CheckInUpdate: nil,
+		CheckInUpdateNew: ForkHeight{
+			Enabled: false,
+			Height:  0,
+		},
 	}
 }
 
@@ -51,22 +57,21 @@ func (app *ShutterApp) IsCheckInUpdateForkActive() bool {
 		log.Warn().Msg("ForkHeights is nil, assuming all forks disabled")
 		return false
 	}
-	forkHeight := app.ForkHeights.CheckInUpdate
-	return isForkActive(forkHeight, override, app.CurrentBlockHeight(), app.EONCounter)
+	return app.ForkHeights.CheckInUpdateNew.IsForkActive(override, app.CurrentBlockHeight(), app.EONCounter)
 }
 
-// isForkActive checks whether a fork is active.
+// IsForkActive checks whether a fork is active.
 //
 // A fork is active in either of the following cases:
 //   - an override is set and the override condition is met
-//   - no override is set, a fork height is set, and current block height
-//     is greater than or equal to the fork height
+//   - no override is set, the fork height enabled flag is set, and the current
+//     block height is greater than or equal to the fork height
 //
 // Otherwise, the fork is not active, i.e., in any of the following cases:
 //   - an override is set but the override condition is not met
-//   - no override is set, a fork height is set, but the current block height is
-//     less than the fork height
-//   - no override is set and no fork height is set
+//   - no override is set, the fork height flag is enabled, but the current
+//     block height is less than the fork height
+//   - no override is set and the fork height enabled flag is not set
 //
 // An override condition is met if
 //   - an override height is set and the current block height is greater than or
@@ -77,7 +82,7 @@ func (app *ShutterApp) IsCheckInUpdateForkActive() bool {
 // If both override height and override eon are set, the height takes
 // precedence. If neither is set, the fork is not active, regardless of the
 // fork height.
-func isForkActive(forkHeightGenesis *int64, override *ForkHeightOverride, currentBlockHeight int64, currentEon uint64) bool {
+func (fh ForkHeight) IsForkActive(override *ForkHeightOverride, currentBlockHeight int64, currentEon uint64) bool {
 	if override != nil {
 		if override.Height != nil {
 			return currentBlockHeight >= *override.Height
@@ -87,8 +92,8 @@ func isForkActive(forkHeightGenesis *int64, override *ForkHeightOverride, curren
 		}
 		return false
 	}
-	if forkHeightGenesis == nil {
+	if !fh.Enabled {
 		return false
 	}
-	return currentBlockHeight >= *forkHeightGenesis
+	return currentBlockHeight >= fh.Height
 }

--- a/rolling-shutter/app/forks_test.go
+++ b/rolling-shutter/app/forks_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestIsForkActive(t *testing.T) {
 	testcases := []struct {
 		name               string
-		forkHeightGenesis  *int64
+		forkHeight         ForkHeight
 		override           *ForkHeightOverride
 		currentBlockHeight int64
 		currentEon         uint64
@@ -51,18 +51,37 @@ func TestIsForkActive(t *testing.T) {
 		},
 		{
 			name:               "genesis height met without override",
-			forkHeightGenesis:  int64Ptr(7),
+			forkHeight:         ForkHeight{Enabled: true, Height: 7},
 			currentBlockHeight: 7,
 			want:               true,
 		},
 		{
 			name:               "genesis height not met without override",
-			forkHeightGenesis:  int64Ptr(7),
+			forkHeight:         ForkHeight{Enabled: true, Height: 7},
 			currentBlockHeight: 6,
 			want:               false,
 		},
 		{
-			name:               "no override and no fork height",
+			name:               "enabled zero height activates at genesis",
+			forkHeight:         ForkHeight{Enabled: true, Height: 0},
+			currentBlockHeight: 0,
+			want:               true,
+		},
+		{
+			name:               "disabled fork with non-zero height stays inactive",
+			forkHeight:         ForkHeight{Enabled: false, Height: 7},
+			currentBlockHeight: 100,
+			want:               false,
+		},
+		{
+			name:               "zero-value fork height is disabled",
+			forkHeight:         ForkHeight{},
+			currentBlockHeight: 100,
+			want:               false,
+		},
+		{
+			name:               "nil override uses fork height",
+			forkHeight:         ForkHeight{Enabled: false, Height: 0},
 			currentBlockHeight: 100,
 			want:               false,
 		},
@@ -71,9 +90,9 @@ func TestIsForkActive(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := isForkActive(tc.forkHeightGenesis, tc.override, tc.currentBlockHeight, tc.currentEon)
+			got := tc.forkHeight.IsForkActive(tc.override, tc.currentBlockHeight, tc.currentEon)
 			if got != tc.want {
-				t.Fatalf("isForkActive() = %t, want %t (test case: %+v)", got, tc.want, tc)
+				t.Fatalf("%s: IsForkActive() = %t, want %t (test case: %+v)", tc.name, got, tc.want, tc)
 			}
 		})
 	}

--- a/rolling-shutter/app/types.go
+++ b/rolling-shutter/app/types.go
@@ -141,11 +141,20 @@ type DKGInstance struct {
 	ApologiesSeen       map[common.Address]struct{}
 }
 
-// ForkHeights stores the block heights at which the rules of the protocol
-// change. If a field is nil, the corresponding fork is never activated,
-// unless overridden in code for specific chain IDs.
+// ForkHeights stores the configuration that controls when protocol forks
+// become active. A fork activates if the `Enabled` flag is true and the
+// current block height reaches `Height`, unless overridden in code for
+// specific chain IDs.
 type ForkHeights struct {
+	// legacy and unused, only present for backwards compatible deserialization
 	CheckInUpdate *int64 `json:"checkInUpdate"`
+
+	CheckInUpdateNew ForkHeight `json:"checkInUpdateNew"`
+}
+
+type ForkHeight struct {
+	Enabled bool
+	Height  int64
 }
 
 type ForkHeightOverrides struct {

--- a/rolling-shutter/cmd/chain/init.go
+++ b/rolling-shutter/cmd/chain/init.go
@@ -168,12 +168,15 @@ func initFiles(_ *cobra.Command, config *Config, _ []string) error {
 	// EnsureRoot also write the config file but with the default config. We want our own, so
 	// let's overwrite it.
 	cfg.WriteConfigFile(config.RootDir+"/config/config.toml", tendermintCfg)
-	// Initialize fork heights according to config. Disabled forks have height nil.
-	forkHeights := app.ForkHeights{}
+	// Initialize fork heights according to config.
+	forkHeights := app.NewForkHeightsAllDisabled()
 	if !config.Forks.CheckInUpdate.Disabled {
-		forkHeights.CheckInUpdate = &config.Forks.CheckInUpdate.Height
+		forkHeights.CheckInUpdateNew = app.ForkHeight{
+			Enabled: true,
+			Height:  config.Forks.CheckInUpdate.Height,
+		}
 	}
-	appState := app.NewGenesisAppState(keypers, (2*len(keypers)+2)/3, config.InitialEon, &forkHeights)
+	appState := app.NewGenesisAppState(keypers, (2*len(keypers)+2)/3, config.InitialEon, forkHeights)
 
 	return initFilesWithConfig(tendermintCfg, config, appState)
 }


### PR DESCRIPTION
Previously, fork heights were specified as pointers to a block height. nil indicated that the fork is disabled, 0 that the fork is enabled from genesis. However, gob does not distinguish the two values, so after an encoding/decoding step both would be turned to nil. This meant that restarting a keyper would disable the fork.

This is fixed by adding an enabled flag for each fork separate from the height field.

Fixes #678 