### PR TITLE
Ensure graceful handling of serialization version mismatches on event trigger definitions

### DIFF
--- a/rolling-shutter/keyperimpl/shutterservice/eventtriggerregisteredprocessor.go
+++ b/rolling-shutter/keyperimpl/shutterservice/eventtriggerregisteredprocessor.go
@@ -85,6 +85,13 @@ func (p *EventTriggerRegisteredEventProcessor) ProcessEvents(ctx context.Context
 		}
 
 		triggerDefinition := EventTriggerDefinition{}
+		if len(registryEvent.TriggerDefinition) > 0 &&
+			registryEvent.TriggerDefinition[0] != Version {
+			evLog.Log().Int64("version", int64(
+				registryEvent.TriggerDefinition[0])).Msg(
+				"skipping trigger definition with outdated version")
+			continue
+		}
 		err := triggerDefinition.UnmarshalBytes(registryEvent.TriggerDefinition)
 		if err != nil {
 			evLog.Info().Err(err).Msg("skipping invalid trigger definition")

--- a/rolling-shutter/keyperimpl/shutterservice/triggerprocessor.go
+++ b/rolling-shutter/keyperimpl/shutterservice/triggerprocessor.go
@@ -63,6 +63,13 @@ func (tp *TriggerProcessor) FetchEvents(ctx context.Context, start, end uint64) 
 			Logger()
 
 		trigger := EventTriggerDefinition{}
+		if len(triggerRegisteredEvent.Definition) > 0 &&
+			triggerRegisteredEvent.Definition[0] != Version {
+			triggerLog.Log().Int64("version", int64(
+				triggerRegisteredEvent.Definition[0])).Msg(
+				"ignoring trigger definition with outdated version in database")
+			continue
+		}
 		err := trigger.UnmarshalBytes(triggerRegisteredEvent.Definition)
 		if err != nil {
 			// This is not supposed to happen as only valid triggers are inserted into the database.


### PR DESCRIPTION
There are to my knowledge only two codepaths that unmarshal event trigger definitions. I've added an explicit version check that will log and skip any entries that do not match the currently implemented serialization version.

Fixes #687 