### PR TITLE
Increase incoming msg buffer

### DIFF
--- a/rolling-shutter/p2p/p2p.go
+++ b/rolling-shutter/p2p/p2p.go
@@ -43,7 +43,7 @@ func init() {
 
 const (
 	// messagesBufSize is the number of incoming messages to buffer for all of the rooms.
-	messagesBufSize = 128
+	messagesBufSize = 512
 	protocolVersion = "/shutter/0.1.0"
 )
 


### PR DESCRIPTION
This change helps with concurrency issues on event based decryption triggers, when many registered decryption keys have to be generated at the same time. Experimentally this increase in buffer size helped to process (and broadcast) key shares for up to 250 registrations succesfully (in a 5 keyper scenario), whereas the previous setting starting failing at around 100 registrations.

This addresses https://github.com/shutter-network/rolling-shutter/issues/715

For a more thorough fix, a (working) batching mechanism needs to be implemented (c.f. https://github.com/shutter-network/rolling-shutter/pull/700)